### PR TITLE
feat: Add rpc_wraperr linter to check error wrapping

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -94,3 +94,8 @@ issues:
   max-same-issues: 0
   exclude-dirs:
     - bin
+  exclude-rules:
+    - path: pkg/factutil/wrapper.go
+      text: "import 'reflect' is not allowed from list 'main'"
+      linters:
+        - depguard # wrapper needs to use reflect.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,15 +10,36 @@ builds:
     binary: rpc_callvalidate
     env:
       - CGO_ENABLED=0
+  - id: "rpc_wraperr"
+    main: ./cmd/wraperr
+    binary: rpc_wraperr
+    env:
+      - CGO_ENABLED=0
 
 archives:
   - id: "rpc_callvalidate"
-    builds: [ rpc_callvalidate ]
+    builds: [ 'rpc_callvalidate' ]
     formats: [ 'tar.gz' ]
     wrap_in_directory: true
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       rpc_callvalidate_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [ 'zip' ]
+  - id: "rpc_wraperr"
+    builds: [ 'rpc_wraperr' ]
+    formats: [ 'tar.gz' ]
+    wrap_in_directory: true
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      rpc_wraperr_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,17 @@ test:
 .PHONY: build
 build:
 	make build/rpc_callvalidate
+	make build/rpc_wraperr
 
 # build/rpc_callvalidate creates the callvalidate binary.
 .PHONY: build/rpc_callvalidate
 build/rpc_callvalidate:
 	@CGO_ENABLED=0 go build -o bin/rpc_callvalidate -v ./cmd/callvalidate
+
+# build/rpc_wraperr creates the wraperr binary.
+.PHONY: build/rpc_wraperr
+build/rpc_wraperr:
+	@CGO_ENABLED=0 go build -o bin/rpc_wraperr -v ./cmd/wraperr
 
 # goreleaser/local runs goreleaser locally.
 # see https://goreleaser.com/quick-start/

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 `rpcguard` is collection of connect-RPC usage linters which check if connect-RPC method is implemented properly.
 
 - rpc_callvalidate: check if RPC method uses Validate method properly
+- rpc_wraperr: check if RPC method returns wrapped error
 
 ## Config
 
 - `rpc_callvalidate` provides options. Please see [callvalidate/config.go](passes/callvalidate/config.go)
+- `rpc_wraperr` provides options. Please see [wraperr/config.go](passes/wraperr/config.go)
 
 You can overwrite via commandline option or golangci setting.
 
@@ -32,11 +34,26 @@ https://aquaproj.github.io/
 $ go vet -vettool=`which rpc_callvalidate` ./...
 ```
 
+```shell
+$ go vet -vettool=`which rpc_wraperr` -rpc_wraperr.IncludePackages="$(go list -m)/.*" ./...
+```
+
+Note: rpc_wraperr.IncludePackages is required option.
+
+
 When you specify config
 
 ```shell
 go vet -vettool=`which rpc_callvalidate` \
   -rpc_callvalidate.LogLevel=ERROR \
+   ./...
+```
+
+```shell
+go vet -vettool=`which rpc_wraperr` \
+  -rpc_wraperr.IncludePackages="$(go list -m)/.*" \
+  -rpc_wraperr.LogLevel=ERROR \
+  -rpc_wraperr.ReportMode=RETURN \
    ./...
 ```
 
@@ -66,4 +83,11 @@ linters-settings:
       description: check if RPC method uses Validate method properly.
       settings:
         LogLevel: "ERROR"
+    rpc_wraperr:
+      type: "module"
+      description:  check if RPC method returns wrapped error.
+      settings:
+        LogLevel: "ERROR"
+        ReportMode: "RETURN"
+        IncludePackages: "github.com/cloverrose/linterplayground/.*"
 ```

--- a/cmd/wraperr/main.go
+++ b/cmd/wraperr/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/unitchecker"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr"
+)
+
+func main() {
+	unitchecker.Main(wraperr.Analyzer)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/golangci/plugin-module-register v0.1.1
+	github.com/google/go-cmp v0.6.0
 	github.com/gostaticanalysis/analysisutil v0.7.1
 	github.com/gostaticanalysis/testutil v0.5.2
 	golang.org/x/tools v0.30.0

--- a/golangci_plugin.go
+++ b/golangci_plugin.go
@@ -2,8 +2,10 @@ package rpcguard
 
 import (
 	"github.com/cloverrose/rpcguard/passes/callvalidate"
+	"github.com/cloverrose/rpcguard/passes/wraperr"
 )
 
 func init() {
 	callvalidate.RegisterPlugin()
+	wraperr.RegisterPlugin()
 }

--- a/passes/wraperr/callgraph/cg.go
+++ b/passes/wraperr/callgraph/cg.go
@@ -1,0 +1,202 @@
+package callgraph
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+	"github.com/cloverrose/rpcguard/pkg/graph"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/rtn"
+	"github.com/cloverrose/rpcguard/passes/wraperr/visitors/norm"
+)
+
+type CallGraph struct {
+	indicesFunc func(fn *ssa.Function) []int
+	order       []*ssa.Function
+	data        map[*ssa.Function]*FuncInfo
+}
+
+func New(indicesFunc func(fn *ssa.Function) []int) *CallGraph {
+	return &CallGraph{
+		indicesFunc: indicesFunc,
+		data:        make(map[*ssa.Function]*FuncInfo),
+	}
+}
+
+func (cg *CallGraph) Scan(srcFunc *ssa.Function) error {
+	indices := cg.indicesFunc(srcFunc)
+	if len(indices) == 0 {
+		return fmt.Errorf("no indices for srcFunc: %s", srcFunc)
+	}
+	cg.order = append(cg.order, srcFunc)
+	info, err := scanFunc(srcFunc, indices)
+	if err != nil {
+		return err
+	}
+
+	cg.data[srcFunc] = info
+	return nil
+}
+
+// scanFunc scans single function and returns all returnInfo.
+func scanFunc(fn *ssa.Function, indices []int) (*FuncInfo, error) {
+	data := make(map[*ssa.Return]*returnInfo)
+	for _, val := range rtn.GetReturnsAt(fn, indices) {
+		info, err := scanVal(val.Value, indices)
+		if err != nil {
+			return nil, err
+		}
+		data[val.Return] = info
+	}
+	return &FuncInfo{data: data}, nil
+}
+
+// scanVal scans single return value and returns returnInfo.
+func scanVal(val ssa.Value, indices []int) (*returnInfo, error) {
+	plugin := &visitorPlugin{
+		normalizeFunc: norm.NewNormalizeFunc(indices),
+	}
+	if err := ssawalk.Walk(ssawalk.NewDefaultVisitorWith(plugin.createOptions()...), val); err != nil {
+		return nil, err
+	}
+	return &returnInfo{
+		toFuncs:        plugin.toFuncs,
+		isObviouslyBad: plugin.isBad,
+	}, nil
+}
+
+type scanPluginFunc func(fn *ssa.Function, indicesFunc func(fn *ssa.Function) []int) (map[*ssa.Return]map[*ssa.Function][]*ssa.Function, error)
+
+// ScanWithPlugin scans fn with plugin and updates call graph.
+func (cg *CallGraph) ScanWithPlugin(plugin scanPluginFunc, fn *ssa.Function) error {
+	if _, ok := cg.data[fn]; !ok {
+		return fmt.Errorf("unexpected: not found for fn: %s", fn)
+	}
+
+	rtnToReplacements, err := plugin(fn, cg.indicesFunc)
+	if err != nil {
+		return err
+	}
+
+	for rt, replacement := range rtnToReplacements {
+		if _, ok := cg.data[fn].data[rt]; !ok {
+			return fmt.Errorf("unexpected: not found for rt: %s", rt)
+		}
+		if len(replacement) == 0 {
+			continue
+		}
+		newToFuncs := make([]*ssa.Function, 0, len(cg.data[fn].data[rt].toFuncs))
+		for _, toFunc := range cg.data[fn].data[rt].toFuncs {
+			converts, ok := replacement[toFunc]
+			if ok {
+				newToFuncs = append(newToFuncs, converts...)
+			} else {
+				newToFuncs = append(newToFuncs, toFunc)
+			}
+		}
+		cg.data[fn].data[rt].toFuncs = newToFuncs
+	}
+	return nil
+}
+
+// GetReturnInfo returns FuncInfo for the given f.
+func (cg *CallGraph) GetReturnInfo(f *ssa.Function) *FuncInfo {
+	info, ok := cg.data[f]
+	if !ok {
+		return nil
+	}
+	return info
+}
+
+// Convert converts CallGraph to Graph.
+func (cg *CallGraph) Convert() *graph.Graph[*ssa.Function] {
+	g := graph.NewGraph[*ssa.Function]()
+	for srcFunc, info := range cg.data {
+		for _, toFunc := range info.GetAllToFuncs() {
+			g.AddEdge(srcFunc, toFunc)
+		}
+	}
+	return g
+}
+
+func (cg *CallGraph) LogValue() slog.Value {
+	coreData := make(map[string][]string, len(cg.data))
+	for srcFunc, info := range cg.data {
+		toFuncs := info.GetAllToFuncs()
+		str := make([]string, 0, len(toFuncs))
+		for _, toFunc := range toFuncs {
+			str = append(str, toFunc.String())
+		}
+		coreData[srcFunc.String()] = str
+	}
+	jsonBytes, err := json.Marshal(coreData)
+	if err != nil {
+		return slog.Value{}
+	}
+	return slog.StringValue(string(jsonBytes))
+}
+
+// returnInfo holds information for single return value.
+type returnInfo struct {
+	toFuncs        []*ssa.Function // source of this return value's functions.
+	isObviouslyBad bool            // if this return is obviously bad or not. E.g. return returns non function (alloc etc).
+}
+
+// FuncInfo holds information for single function.
+// Single function has several returns, data holds mapping from return to returnInfo.
+type FuncInfo struct {
+	data map[*ssa.Return]*returnInfo
+}
+
+// GetReturns returns all returns of single function.
+func (i *FuncInfo) GetReturns() []*ssa.Return {
+	return slices.Collect(maps.Keys(i.data))
+}
+
+// GetAllToFuncs returns all functions that are called from this function.
+func (i *FuncInfo) GetAllToFuncs() []*ssa.Function {
+	ret := make([]*ssa.Function, 0, len(i.data))
+	for _, info := range i.data {
+		ret = append(ret, info.toFuncs...)
+	}
+	return ret
+}
+
+// IsObviouslyBad returns true if this function is obviously bad.
+func (i *FuncInfo) IsObviouslyBad() bool {
+	for _, info := range i.data {
+		if info.isObviouslyBad {
+			return true
+		}
+	}
+	return false
+}
+
+// IsObviouslyOK returns true if this function is obviously ok.
+func (i *FuncInfo) IsObviouslyOK() bool {
+	return !i.IsObviouslyBad() && len(i.GetAllToFuncs()) == 0
+}
+
+// IsObviouslyBadReturn returns true if given rtn is obviously bad.
+func (i *FuncInfo) IsObviouslyBadReturn(rtn *ssa.Return) bool {
+	info, ok := i.data[rtn]
+	if !ok {
+		return false
+	}
+	return info.isObviouslyBad
+}
+
+// GetToFuncs returns toFuncs for the given rtn.
+func (i *FuncInfo) GetToFuncs(rtn *ssa.Return) []*ssa.Function {
+	info, ok := i.data[rtn]
+	if !ok {
+		return nil
+	}
+	return info.toFuncs
+}

--- a/passes/wraperr/callgraph/plugin/eg/scan.go
+++ b/passes/wraperr/callgraph/plugin/eg/scan.go
@@ -1,0 +1,86 @@
+package eg
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/rtn"
+)
+
+// This file contains errgroup support.
+// Below sample code,
+// Foo: eg.Wait() returns connect.NewError
+// Bar: eg.Wait() returns normal error
+// However, ssa can't connect Foo to Foo$1, instead ssa connects Foo to eg.Go.
+// Thus without special cares, we need to mark Foo as bad func because we can't analyze further.
+// This file provides that special cares.
+
+/**
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	"golang.org/x/sync/errgroup"
+)
+
+func Foo(ctx context.Context, x int) (int, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { // <- in ssa, this anonymous func name is Foo$1
+		return okFunc1(ctx, x)
+	})
+	if err := eg.Wait(); err != nil {
+		return 0, err
+	}
+	return x, nil
+}
+
+func Bar(ctx context.Context, x int) (int, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { // <- in ssa, this anonymous func name is Bar$1
+		return badFunc1(ctx, x)
+	})
+	if err := eg.Wait(); err != nil {
+		return 0, err
+	}
+	return x, nil
+}
+
+// okFunc1 use connect.NewError
+func okFunc1(ctx context.Context, x int) error {
+	if x == 0 {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("err"))
+	}
+	return nil
+}
+
+// badFunc1 doesn't use connect.NewError
+func badFunc1(ctx context.Context, x int) error {
+	if x == 0 {
+		return errors.New("err")
+	}
+	return nil
+}
+**/
+
+func Scan(fn *ssa.Function, indicesFunc func(fn *ssa.Function) []int) (map[*ssa.Return]map[*ssa.Function][]*ssa.Function, error) {
+	indices := indicesFunc(fn)
+	if len(indices) == 0 {
+		// srcFunc does not return error-ish values.
+		return nil, fmt.Errorf("no indices for fn: %s", fn)
+	}
+
+	rtnToReplacements := make(map[*ssa.Return]map[*ssa.Function][]*ssa.Function)
+	for _, val := range rtn.GetReturnsAt(fn, indices) {
+		plugin := newVisitorPlugin()
+		visitor := ssawalk.NewDefaultVisitorWith(plugin.createOptions()...)
+		if err := ssawalk.Walk(visitor, val.Value); err != nil {
+			return nil, err
+		}
+		rtnToReplacements[val.Return] = plugin.replacements
+	}
+	return rtnToReplacements, nil
+}

--- a/passes/wraperr/callgraph/plugin/eg/util.go
+++ b/passes/wraperr/callgraph/plugin/eg/util.go
@@ -1,0 +1,51 @@
+package eg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// isGo returns true if fn is (*golang.org/x/sync/errgroup.Group).Go()
+func isGo(fn *ssa.Function) bool {
+	if fn == nil || fn.Pkg == nil || fn.Pkg.Pkg == nil {
+		return false
+	}
+	path := fn.Pkg.Pkg.Path()
+	const errGroupPath = "golang.org/x/sync/errgroup"
+	return (path == errGroupPath || strings.HasSuffix(path, "vendor/"+errGroupPath)) && fn.Name() == "Go"
+}
+
+// isWait returns true if fn is (*golang.org/x/sync/errgroup.Group).Wait()
+func isWait(fn *ssa.Function) bool {
+	if fn == nil || fn.Pkg == nil || fn.Pkg.Pkg == nil {
+		return false
+	}
+	path := fn.Pkg.Pkg.Path()
+	const errGroupPath = "golang.org/x/sync/errgroup"
+	return (path == errGroupPath || strings.HasSuffix(path, "vendor/"+errGroupPath)) && fn.Name() == "Wait"
+}
+
+// getGoArg returns eg.Go args receiver and func-ish value
+//
+//nolint:ireturn // interface ssa.Value is ok to return.
+func getGoArg(call ssa.CallCommon) (receiver, arg ssa.Value, err error) {
+	if len(call.Args) != 2 {
+		// eg.Go(f) <- Args should be [receiver, f]
+		return nil, nil, fmt.Errorf("expected 2 arguments, got %d", len(call.Args))
+	}
+	return call.Args[0], call.Args[1], nil
+}
+
+// getWaitReceiver returns eg.Wait receiver
+//
+//nolint:ireturn // interface ssa.Value is ok to return.
+func getWaitReceiver(call ssa.CallCommon) (ssa.Value, error) {
+	if len(call.Args) != 1 {
+		// eg.Wait() <- Args should be [receiver]
+		return nil, errors.New("unexpected: len(call.Args) != 1")
+	}
+	return call.Args[0], nil
+}

--- a/passes/wraperr/callgraph/plugin/eg/visitor.go
+++ b/passes/wraperr/callgraph/plugin/eg/visitor.go
@@ -1,0 +1,111 @@
+package eg
+
+import (
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/visitors/call2func"
+	"github.com/cloverrose/rpcguard/passes/wraperr/visitors/norm"
+)
+
+type visitorPlugin struct {
+	replacements map[*ssa.Function][]*ssa.Function
+}
+
+func newVisitorPlugin() *visitorPlugin {
+	return &visitorPlugin{
+		replacements: make(map[*ssa.Function][]*ssa.Function),
+	}
+}
+
+func (p *visitorPlugin) createOptions() []ssawalk.Option {
+	return []ssawalk.Option{
+		ssawalk.WithVisitCall(p.VisitCall),
+	}
+}
+
+func (p *visitorPlugin) VisitCall(call *ssa.Call) error {
+	// Check if call is eg.Wait()
+	waitFunc, err := call2func.GetFuncFromCall(call)
+	if err != nil {
+		return err
+	}
+	if waitFunc == nil {
+		return nil
+	}
+	if !isWait(waitFunc) {
+		return nil
+	}
+
+	// Find eg.Wait() receiver eg
+	receiver, err := getWaitReceiver(call.Call)
+	if err != nil {
+		return err
+	}
+
+	// Find eg.Go(func) funcs
+	refs := receiver.Referrers()
+	if refs == nil {
+		// eg.Wait is called but there is no eg.Go.
+		return nil
+	}
+	for _, instr := range *refs {
+		goCall, ok := instr.(*ssa.Call)
+		if !ok {
+			continue
+		}
+		goArgFunc, err := getGoArgFunc(goCall, receiver)
+		if err != nil {
+			return err
+		}
+		if goArgFunc != nil {
+			p.replacements[waitFunc] = append(p.replacements[waitFunc], goArgFunc)
+		}
+	}
+	return nil
+}
+
+func getGoArgFunc(egCall *ssa.Call, waitReceiver ssa.Value) (*ssa.Function, error) {
+	// Check if call is eg.Go()
+	goFunc, err := call2func.GetFuncFromCall(egCall)
+	if err != nil {
+		return nil, err
+	}
+	if goFunc == nil {
+		return nil, nil
+	}
+	if !isGo(goFunc) {
+		return nil, nil
+	}
+
+	// Get eg.Go(fun) receiver and argument fun.
+	goReceiver, goArg, err := getGoArg(egCall.Call)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if eg.Go() receiver is the same with eg.Wait() receiver.
+	if goReceiver != waitReceiver {
+		panic("unexpected: goReceiver != waitReceiver")
+	}
+
+	// Find eg.Go(fun) argument func from goArg.
+	// goArg can be not *ssa.Function
+	//   goArg is *ssa.Function: eg.Go(fun): return fun.
+	//   goArg is *ssa.Call: eg.Go(higherOrderFun()): return higherOrderFun.
+	goArgFunc, err := call2func.GetFuncFromCall(goArg)
+	if err != nil {
+		return nil, err
+	}
+	if goArgFunc == nil {
+		return nil, nil
+	}
+
+	// normalize
+	normed, err := norm.NewNormalizeFunc([]int{0})(goArgFunc)
+	if err != nil {
+		return nil, err
+	}
+	return normed, nil
+}

--- a/passes/wraperr/callgraph/visitor.go
+++ b/passes/wraperr/callgraph/visitor.go
@@ -1,0 +1,74 @@
+package callgraph
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/gostaticanalysis/analysisutil"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+)
+
+// visitorPlugin visit ssa.Value and collects ssa.Function that are source of returned value.
+// If it visits ssa.Value that is not func, ignore.
+type visitorPlugin struct {
+	normalizeFunc func(fn *ssa.Function) (*ssa.Function, error)
+
+	toFuncs []*ssa.Function
+	isBad   bool
+}
+
+func (p *visitorPlugin) VisitFunction(val *ssa.Function) error {
+	normed, err := p.normalizeFunc(val)
+	if err != nil {
+		return err
+	}
+	p.toFuncs = append(p.toFuncs, normed)
+	return nil
+}
+
+func (p *visitorPlugin) VisitConst(val *ssa.Const) error {
+	if !analysisutil.ImplementsError(val.Type()) {
+		// srcFunc calls const func. e.g.
+		// func Hello() error {
+		//   var constFunc func() error
+		//   return constFunc()
+		// }
+		p.isBad = true
+	}
+	if !val.IsNil() {
+		panic(fmt.Sprintf("unexpected const %s\n", val.Name()))
+	}
+	return nil
+}
+
+func (p *visitorPlugin) VisitAlloc(val *ssa.Alloc) error {
+	// usually alloc err is badFunc
+	p.isBad = true
+	return nil
+}
+
+func (p *visitorPlugin) VisitComplex(val ssa.Value) error {
+	// can't analyze further due to complexity, treat badFunc.
+	p.isBad = true
+	return nil
+}
+
+func (p *visitorPlugin) VisitCallInvoke(val *ssa.Call) error {
+	// can't analyze further due to interface method.
+	// However, interface method is usually defined in different package.
+	// Then it can be considered badFunc.
+	p.isBad = true
+	return nil
+}
+
+func (p *visitorPlugin) createOptions() []ssawalk.Option {
+	return []ssawalk.Option{
+		ssawalk.WithVisitFunction(p.VisitFunction),
+		ssawalk.WithVisitConst(p.VisitConst),
+		ssawalk.WithVisitAlloc(p.VisitAlloc),
+		ssawalk.WithVisitComplex(p.VisitComplex),
+		ssawalk.WithVisitCallInvoke(p.VisitCallInvoke),
+	}
+}

--- a/passes/wraperr/config.go
+++ b/passes/wraperr/config.go
@@ -1,0 +1,62 @@
+package wraperr
+
+import (
+	"github.com/cloverrose/rpcguard/pkg/filter"
+)
+
+// LogLevel is configuration of logging level.
+// Available options are DEBUG, INFO, WARN, ERROR
+var LogLevel = "INFO"
+
+const (
+	reportModeReturn   = "RETURN"
+	reportModeFunction = "FUNCTION"
+	reportModeBoth     = "BOTH"
+)
+
+// ReportMode is configuration of how to report violation.
+// Available options are RETURN, FUNCTION, BOTH.
+// - RETURN: Report violations at return instruction level. It provides detailed information, and you can find violation easily.
+// - FUNCTION: Report violations at function level. It is convenient if you use nolint.
+// - BOTH: Report violations both levels. This mode is mainly for unit test of wraperr itself.
+var ReportMode = reportModeReturn
+
+// IncludePackages is configuration which packages should be included.
+// Multiple Packages can be specified by using commas (,).
+// e.g. github.com/foo/bar/a/includedpkg/hello,github.com/foo/bar/common
+//
+// [Explain with example]
+// There are two packages,
+//   - package hello (path=github.com/foo/bar/a/includedpkg/hello) <- Let's say hello defines RPC method Hello.
+//   - package errutil (path=github.com/foo/bar/common/errutil) <- Let's say errutil provides func that converts error with connect.NewError.
+//
+// hello's Hello calls errutil's ConvertErr.
+// Regardless of this configuration, wraperr understands that Hello() is calling ConvertErr().
+// If this configuration doesn't include "github.com/foo/bar/common/errutil", wraperr doesn't know whether ConvertErr()'s error is connect.NewError or not.
+// Thus, wraperr reports, Hello() can return non connect.NewError errors.
+// So, includes enough package path prefix is important for precise reports.
+// On the other hand, extending the search area is computationally time-consuming.
+// Narrowing down the search to only relevant Packages can improve efficiency.
+var IncludePackages = ""
+
+// ExcludePackages is configuration which packages should be excluded.
+// This is useful to exclude vendor.
+var ExcludePackages = ""
+
+// ExcludeFiles is configuration which files should be excluded.
+// This is useful to exclude test file, generated files.
+// To set the same value with the default config, use this command line argument.
+// -rpc_wraperr.ExcludeFiles='.+_test\.go,.+\.connect\.go'
+var ExcludeFiles = `.+_test\.go,.+\.connect\.go`
+
+// EnableErrGroupAnalyzer is configuration whether enable ErrGroupAnalyzer.
+// Default is true and recommend to keep true.
+// The reason for this configuration item is to share with users that
+// wraperr can be incorrect in a false positive sense for propagation of errors that it does not support.
+// errgroup is supported, but others such as hashicorp/go-multierror is not supported.
+var EnableErrGroupAnalyzer = true
+
+var (
+	packageFilter *filter.Filter
+	fileFilter    *filter.Filter
+)

--- a/passes/wraperr/fact.go
+++ b/passes/wraperr/fact.go
@@ -1,0 +1,28 @@
+package wraperr
+
+type Kind uint32
+
+const (
+	KindUnknown Kind = iota
+	KindOK
+	KindBad
+)
+
+type isErrorHandler struct {
+	Kind Kind
+}
+
+func (f *isErrorHandler) AFact() {}
+
+func (f *isErrorHandler) String() string {
+	switch f.Kind {
+	case KindUnknown:
+		return "unknownFunc"
+	case KindOK:
+		return "okFunc"
+	case KindBad:
+		return "badFunc"
+	default:
+		panic("unreachable")
+	}
+}

--- a/passes/wraperr/golangci_plugin.go
+++ b/passes/wraperr/golangci_plugin.go
@@ -1,0 +1,60 @@
+package wraperr
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+)
+
+func RegisterPlugin() {
+	// https://golangci-lint.run/plugins/module-plugins/
+	register.Plugin("rpc_wraperr", newPlugin)
+}
+
+func newPlugin(conf any) (register.LinterPlugin, error) {
+	s, err := register.DecodeSettings[settings](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &plugin{settings: &s}, nil
+}
+
+type settings struct {
+	LogLevel               string
+	ReportMode             string
+	IncludePackages        string
+	ExcludePackages        string
+	ExcludeFiles           string
+	EnableErrGroupAnalyzer bool
+}
+
+type plugin struct {
+	settings *settings
+}
+
+func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	if p.settings.LogLevel != "" {
+		LogLevel = p.settings.LogLevel
+	}
+	if p.settings.ReportMode != "" {
+		ReportMode = p.settings.ReportMode
+	}
+	if p.settings.IncludePackages != "" {
+		IncludePackages = p.settings.IncludePackages
+	}
+	if p.settings.ExcludePackages != "" {
+		ExcludePackages = p.settings.ExcludePackages
+	}
+	if p.settings.ExcludeFiles != "" {
+		ExcludeFiles = p.settings.ExcludeFiles
+	}
+	return []*analysis.Analyzer{
+		Analyzer,
+	}, nil
+}
+
+func (p *plugin) GetLoadMode() string {
+	return register.LoadModeSyntax
+}
+
+var _ register.LinterPlugin = &plugin{}

--- a/passes/wraperr/mark.go
+++ b/passes/wraperr/mark.go
@@ -1,0 +1,156 @@
+package wraperr
+
+import (
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/factutil"
+	"github.com/cloverrose/rpcguard/pkg/logger"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/callgraph"
+)
+
+type factImporter interface {
+	Import(fn *ssa.Function) (*isErrorHandler, bool)
+}
+
+// markSCCs checks and records facts.
+func markSCCs(pass *analysis.Pass, sccs [][]*ssa.Function, factWrapper *factutil.FactWrapper[*isErrorHandler],
+	cg *callgraph.CallGraph,
+) error {
+	for _, scc := range sccs {
+		bad, err := checkSCC(pass, scc, factWrapper, cg)
+		if err != nil {
+			return err
+		}
+		propagateMarkToSCC(scc, bad, factWrapper)
+	}
+	return nil
+}
+
+// checkSCC checks if given scc has bad error sources or not.
+func checkSCC(
+	pass *analysis.Pass,
+	scc []*ssa.Function,
+	factWrapper factImporter,
+	cg *callgraph.CallGraph,
+) (bool, error) {
+	for _, fromFunc := range scc {
+		bad, err := checkFunc(pass, factWrapper, fromFunc, scc, cg)
+		if err != nil {
+			return false, err
+		}
+		if bad {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func checkFunc(
+	pass *analysis.Pass,
+	factWrapper factImporter,
+	srcFunc *ssa.Function,
+	scc []*ssa.Function,
+	cg *callgraph.CallGraph,
+) (bool, error) {
+	slog.Debug("check srcFunc", logger.Attr(srcFunc))
+
+	fact, ok := factWrapper.Import(srcFunc)
+	if ok {
+		switch fact.Kind {
+		case KindUnknown:
+			panic(unexpectedUnknown)
+		case KindBad:
+			return true, nil
+		case KindOK:
+			return false, nil
+		}
+	}
+	if isConnectNewError(srcFunc) {
+		return false, nil
+	}
+	if srcFunc == nil {
+		panic("unexpected srcFunc is nil")
+	}
+	if srcFunc.Pkg == nil {
+		// This happens when interface method is assigned to local variable.
+		// E.g. fn := app.handler.Handle
+		slog.Debug("found bad func (srcFunc.Pkg is nil)", logger.Attr(srcFunc))
+		return true, nil
+	}
+	if srcFunc.Pkg.Pkg != pass.Pkg {
+		// srcFunc is defined in different package.
+		// and fact is unknown, so it is unknown bad func.
+		slog.Debug("found bad func (srcFunc.Pkg.Pkg != pass.Pkg)", logger.Attr(srcFunc))
+		return true, nil
+	}
+
+	var bad bool
+	info := cg.GetReturnInfo(srcFunc)
+	if info == nil {
+		panic(fmt.Sprintf("unexpected info not found for srcFunc: %s", srcFunc.Name()))
+	}
+	for _, toFunc := range info.GetAllToFuncs() {
+		if slices.Contains(scc, toFunc) {
+			slog.Debug("toFunc is in the same SCC", logger.Attr(toFunc))
+			continue
+		}
+		if isConnectNewError(toFunc) {
+			continue
+		}
+		bad = checkBad(toFunc, factWrapper)
+		if bad {
+			break
+		}
+	}
+	if bad {
+		slog.Debug("func is bad func", logger.Attr(srcFunc))
+	} else {
+		slog.Debug("func is not bad (still suspicious)", logger.Attr(srcFunc))
+	}
+	return bad, nil
+}
+
+func checkBad(toFunc *ssa.Function, factWrapper factImporter) bool {
+	fact, ok := factWrapper.Import(toFunc)
+	if ok {
+		switch fact.Kind {
+		case KindUnknown:
+			panic(unexpectedUnknown)
+		case KindBad:
+			return true
+		case KindOK:
+			return false
+		}
+	}
+	// toFunc is not in facts => badFunc
+	return true
+}
+
+// isConnectNewError returns true if fn is connect.NewError.
+func isConnectNewError(fn *ssa.Function) bool {
+	if fn == nil || fn.Pkg == nil || fn.Pkg.Pkg == nil {
+		return false
+	}
+	path := fn.Pkg.Pkg.Path()
+	const connectPath = "connectrpc.com/connect"
+	return (path == connectPath || strings.HasSuffix(path, "vendor/"+connectPath)) && fn.Name() == "NewError"
+}
+
+func propagateMarkToSCC(scc []*ssa.Function, bad bool, factWrapper *factutil.FactWrapper[*isErrorHandler]) {
+	for _, fn := range scc {
+		slog.Debug("propagate mark", logger.Attr(fn), slog.Bool("bad", bad))
+		// Export kind
+		if bad {
+			factWrapper.Export(fn, &isErrorHandler{Kind: KindBad})
+		} else {
+			factWrapper.Export(fn, &isErrorHandler{Kind: KindOK})
+		}
+	}
+}

--- a/passes/wraperr/rtn/util.go
+++ b/passes/wraperr/rtn/util.go
@@ -1,0 +1,39 @@
+package rtn
+
+import (
+	"golang.org/x/tools/go/ssa"
+)
+
+type ReturnAndValue struct {
+	Return *ssa.Return
+	Value  ssa.Value
+}
+
+// GetReturnsAt returns returns at index for the given fn.
+// func Hello() (int, error) if indices = []{1}, returns error related returns.
+func GetReturnsAt(fn *ssa.Function, indices []int) []ReturnAndValue {
+	rtns := getReturns(fn)
+	ats := make([]ReturnAndValue, 0, len(rtns))
+	for _, rtn := range rtns {
+		for _, index := range indices {
+			ats = append(ats, ReturnAndValue{
+				Return: rtn,
+				Value:  rtn.Results[index],
+			})
+		}
+	}
+	return ats
+}
+
+// getReturns returns all returns for the given fn.
+func getReturns(fn *ssa.Function) []*ssa.Return {
+	var rtns []*ssa.Return
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if rtn, ok := instr.(*ssa.Return); ok {
+				rtns = append(rtns, rtn)
+			}
+		}
+	}
+	return rtns
+}

--- a/passes/wraperr/testdata/src/a/a01core/01_app.go
+++ b/passes/wraperr/testdata/src/a/a01core/01_app.go
@@ -1,0 +1,7 @@
+package a01core
+
+type App struct{}
+
+type Message struct {
+	text string
+}

--- a/passes/wraperr/testdata/src/a/a01core/02_rpc_method.go
+++ b/passes/wraperr/testdata/src/a/a01core/02_rpc_method.go
@@ -1,0 +1,39 @@
+package a01core
+
+// This file contains RPC methods.
+// Note: The wraperr specifically reports only on RPC methods.
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// ReturnNil returns nil
+func (app *App) ReturnNil(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnNil:"okFunc"
+	return connect.NewResponse(&Message{"ReturnNil"}), nil
+}
+
+// ReturnWrapError returns connect.NewError
+func (app *App) ReturnWrapError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnWrapError:"okFunc"
+	return nil, connect.NewError(connect.CodeInternal, errors.New("ReturnWrapError"))
+}
+
+// ReturnUnwrapError returns unwrap error
+func (app *App) ReturnUnwrapError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnUnwrapError:"badFunc"  ".*RPC method ReturnUnwrapError returns error.*"
+	return nil, errors.New("ReturnUnwrapError") // want ".*RPC method ReturnUnwrapError returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+type myError struct{}
+
+func (e *myError) Error() string {
+	return "myError"
+}
+
+// ReturnAllocError returns Alloc error without wrap
+func (app *App) ReturnAllocError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnAllocError:"badFunc"  ".*RPC method ReturnAllocError returns error.*"
+	return nil, &myError{} // want ".*RPC method ReturnAllocError returns error.*"
+}

--- a/passes/wraperr/testdata/src/a/a01core/03_non_rpc_method.go
+++ b/passes/wraperr/testdata/src/a/a01core/03_non_rpc_method.go
@@ -1,0 +1,15 @@
+package a01core
+
+// This file contains methods those signatures don't match RPC method.
+// Note: The wraperr specifically reports only on RPC methods.
+
+import (
+	"context"
+	"errors"
+)
+
+// returnOnlyUnwrapError returns unwrap error.
+// This method signature does not match RPC method, so no report.
+func (app *App) returnOnlyUnwrapError(_ context.Context) error { // want returnOnlyUnwrapError:"badFunc"
+	return errors.New("returnOnlyUnwrapError")
+}

--- a/passes/wraperr/testdata/src/a/a01core/04_function.go
+++ b/passes/wraperr/testdata/src/a/a01core/04_function.go
@@ -1,0 +1,27 @@
+package a01core
+
+// This file contains standalone functions without receivers.
+// Note: The wraperr specifically reports only on methods.
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// returnNilFunc returns nil
+func returnNilFunc(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want returnNilFunc:"okFunc"
+	return connect.NewResponse(&Message{"returnNilFunc"}), nil
+}
+
+// returnWrapErrorFunc returns connect.NewError
+func returnWrapErrorFunc(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want returnWrapErrorFunc:"okFunc"
+	return nil, connect.NewError(connect.CodeInternal, errors.New("returnWrapErrorFunc"))
+}
+
+// returnUnwrapErrorFunc returns unwrap error
+// This method signature does not match RPC method, so no report.
+func returnUnwrapErrorFunc(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want returnUnwrapErrorFunc:"badFunc"
+	return nil, errors.New("returnUnwrapErrorFunc")
+}

--- a/passes/wraperr/testdata/src/a/a01core/05_nested.go
+++ b/passes/wraperr/testdata/src/a/a01core/05_nested.go
@@ -1,0 +1,46 @@
+package a01core
+
+// This file contains methods which calls other methods or functions.
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+// CallOKRPCMethod calls member method that is okFunc and return error directly.
+func (app *App) CallOKRPCMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallOKRPCMethod:"okFunc"
+	return app.ReturnWrapError(ctx, req)
+}
+
+// CallBadRPCMethod calls member method that is badFunc and return error directly.
+func (app *App) CallBadRPCMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallBadRPCMethod:"badFunc" ".*RPC method CallBadRPCMethod returns error.*"
+	return app.ReturnUnwrapError(ctx, req) // want ".*RPC method CallBadRPCMethod returns error.*"
+}
+
+// CallBadNonRPCMethod calls member method that is badFunc
+func (app *App) CallBadNonRPCMethod(ctx context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want CallBadNonRPCMethod:"badFunc" ".*RPC method CallBadNonRPCMethod returns error.*"
+	if err := app.returnOnlyUnwrapError(ctx); err != nil {
+		return nil, err // want ".*RPC method CallBadNonRPCMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallBadNonRPCMethod"}), nil
+}
+
+// CallBadFunc calls function that is badFunc and return error directly.
+func (app *App) CallBadFunc(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallBadFunc:"badFunc" ".*RPC method CallBadFunc returns error.*"
+	return returnUnwrapErrorFunc(ctx, req) // want ".*RPC method CallBadFunc returns error.*"
+}
+
+// CallBadMethodButWrap calls member method that is badFunc but wrap error
+func (app *App) CallBadMethodButWrap(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallBadMethodButWrap:"okFunc"
+	res, err := app.ReturnUnwrapError(ctx, req)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return res, nil
+}
+
+// CallNestedBadMethod calls member method that is badFunc
+func (app *App) CallNestedBadMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallNestedBadMethod:"badFunc" ".*RPC method CallNestedBadMethod returns error.*"
+	return app.CallBadRPCMethod(ctx, req) // want ".*RPC method CallNestedBadMethod returns error.*"
+}

--- a/passes/wraperr/testdata/src/a/a01core/06_higherorder.go
+++ b/passes/wraperr/testdata/src/a/a01core/06_higherorder.go
@@ -1,0 +1,96 @@
+package a01core
+
+// This file contains higher order methods.
+// Note: Fact is record even for higher order func if that calling such func will return error in the end.
+// Note: The wraperr does not report higher order methods.
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// ReturnOkClosure returns closure that returns wrap error.
+// Return anonymous func.
+func (app *App) ReturnOkClosure(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnOkClosure:"okFunc"
+	return func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("ReturnOkClosure"))
+	}
+}
+
+// CallReturnOkClosure calls and returns error directly.
+func (app *App) CallReturnOkClosure(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnOkClosure:"okFunc"
+	return app.ReturnOkClosure(ctx, req)(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnBadClosure returns closure that returns unwrap error.
+// Return anonymous func.
+func (app *App) ReturnBadClosure(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnBadClosure:"badFunc"
+	return func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return nil, errors.New("ReturnBadClosure")
+	}
+}
+
+// CallReturnBadClosure calls and returns error directly.
+func (app *App) CallReturnBadClosure(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnBadClosure:"badFunc" ".*RPC method CallReturnBadClosure returns error.*"
+	return app.ReturnBadClosure(ctx, req)(ctx, req) // want ".*RPC method CallReturnBadClosure returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnOKMethod returns member method that returns wrap error
+func (app *App) ReturnOKMethod(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnOKMethod:"okFunc"
+	return app.ReturnWrapError
+}
+
+// CallReturnOKMethod calls and returns error directly.
+func (app *App) CallReturnOKMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnOKMethod:"okFunc"
+	return app.ReturnOKMethod(ctx, req)(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnBadMethod returns member method that returns unwrap error
+func (app *App) ReturnBadMethod(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnBadMethod:"badFunc"
+	return app.ReturnUnwrapError
+}
+
+// CallReturnBadMethod calls and returns error directly.
+func (app *App) CallReturnBadMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnBadMethod:"badFunc" ".*RPC method CallReturnBadMethod returns error.*"
+	return app.ReturnBadMethod(ctx, req)(ctx, req) // want ".*RPC method CallReturnBadMethod returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnOKFunc returns function that returns wrap error
+func (app *App) ReturnOKFunc(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnOKFunc:"okFunc"
+	return returnWrapErrorFunc
+}
+
+// CallReturnOKFunc calls and returns error directly.
+func (app *App) CallReturnOKFunc(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnOKFunc:"okFunc"
+	return app.ReturnOKFunc(ctx, req)(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnBadFunc returns function that returns unwrap error
+func (app *App) ReturnBadFunc(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnBadFunc:"badFunc"
+	return returnUnwrapErrorFunc
+}
+
+// CallReturnBadFunc calls and returns error directly.
+func (app *App) CallReturnBadFunc(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnBadFunc:"badFunc" ".*RPC method CallReturnBadFunc returns error.*"
+	return app.ReturnBadFunc(ctx, req)(ctx, req) // want ".*RPC method CallReturnBadFunc returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnNilClosure returns nil closure.
+// nil closure is considered as bad closure, then the wraperr records badFunc Fact.
+func (app *App) ReturnNilClosure(_ context.Context, _ *connect.Request[Message]) func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnNilClosure:"badFunc"
+	return nil
+}

--- a/passes/wraperr/testdata/src/a/a01core/07_higherorder2.go
+++ b/passes/wraperr/testdata/src/a/a01core/07_higherorder2.go
@@ -1,0 +1,100 @@
+package a01core
+
+// This file contains nested higher order methods.
+// Note: Fact is record even for higher order func if that calling such func will return error in the end.
+// Note: The wraperr does not report higher order methods.
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// ReturnReturnOkClosure returns nested closure that returns wrap error.
+// Return anonymous func.
+func (app *App) ReturnReturnOkClosure(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnOkClosure:"okFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+			return nil, connect.NewError(connect.CodeInternal, errors.New("ReturnReturnOkClosure"))
+		}
+	}
+}
+
+// CallReturnReturnOkClosure calls and returns error directly.
+func (app *App) CallReturnReturnOkClosure(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnOkClosure:"okFunc"
+	return app.ReturnReturnOkClosure(ctx, req)()(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnReturnBadClosure returns nested closure that returns unwrap error.
+// Return anonymous func.
+func (app *App) ReturnReturnBadClosure(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnBadClosure:"badFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+			return nil, errors.New("ReturnReturnBadClosure")
+		}
+	}
+}
+
+// CallReturnReturnBadClosure calls and returns error directly.
+func (app *App) CallReturnReturnBadClosure(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnBadClosure:"badFunc" ".*RPC method CallReturnReturnBadClosure returns error.*"
+	return app.ReturnReturnBadClosure(ctx, req)()(ctx, req) // want ".*RPC method CallReturnReturnBadClosure returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnReturnOKMethod returns closure that returns member method that returns wrap error
+func (app *App) ReturnReturnOKMethod(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnOKMethod:"okFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return app.ReturnWrapError
+	}
+}
+
+// CallReturnReturnOKMethod calls and returns error directly.
+func (app *App) CallReturnReturnOKMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnOKMethod:"okFunc"
+	return app.ReturnReturnOKMethod(ctx, req)()(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnReturnBadMethod returns closure that returns member method that returns unwrap error
+func (app *App) ReturnReturnBadMethod(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnBadMethod:"badFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return app.ReturnUnwrapError
+	}
+}
+
+// CallReturnReturnBadMethod calls and returns error directly.
+func (app *App) CallReturnReturnBadMethod(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnBadMethod:"badFunc" ".*RPC method CallReturnReturnBadMethod returns error.*"
+	return app.ReturnReturnBadMethod(ctx, req)()(ctx, req) // want ".*RPC method CallReturnReturnBadMethod returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnReturnOKFunc returns closure that returns function that returns wrap error
+func (app *App) ReturnReturnOKFunc(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnOKFunc:"okFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return returnWrapErrorFunc
+	}
+}
+
+// CallReturnReturnOKFunc calls and returns error directly.
+func (app *App) CallReturnReturnOKFunc(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnOKFunc:"okFunc"
+	return app.ReturnReturnOKFunc(ctx, req)()(ctx, req)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReturnReturnBadFunc returns closure that returns function that returns unwrap error
+func (app *App) ReturnReturnBadFunc(_ context.Context, _ *connect.Request[Message]) func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnReturnBadFunc:"badFunc"
+	return func() func(context.Context, *connect.Request[Message]) (*connect.Response[Message], error) {
+		return returnUnwrapErrorFunc
+	}
+}
+
+// CallReturnReturnBadFunc calls and returns error directly.
+func (app *App) CallReturnReturnBadFunc(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnReturnBadFunc:"badFunc" ".*RPC method CallReturnReturnBadFunc returns error.*"
+	return app.ReturnReturnBadFunc(ctx, req)()(ctx, req) // want ".*RPC method CallReturnReturnBadFunc returns error.*"
+}

--- a/passes/wraperr/testdata/src/a/a02phi/phi.go
+++ b/passes/wraperr/testdata/src/a/a02phi/phi.go
@@ -1,0 +1,80 @@
+package a02phi
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+type App struct{}
+
+type Message struct {
+	text string
+}
+
+// PhiAllWrapErrorIf returns error its sources are all wrap error
+func (app *App) PhiAllWrapErrorIf(_ context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want PhiAllWrapErrorIf:"okFunc"
+	var err error
+	if req.Msg.text == "hello" {
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error 1"))
+	} else {
+		err = connect.NewError(connect.CodeNotFound, errors.New("wrap error 2"))
+	}
+	return connect.NewResponse(&Message{"PhiAllWrapErrorIf"}), err
+}
+
+// PhiUnwrapErrorIf returns error its sources contain unwrap error
+func (app *App) PhiUnwrapErrorIf(_ context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want PhiUnwrapErrorIf:"badFunc" ".*RPC method PhiUnwrapErrorIf returns error.*"
+	var err error
+	if req.Msg.text == "hello" {
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error"))
+	} else {
+		err = errors.New("unwrap error")
+	}
+	return connect.NewResponse(&Message{"PhiUnwrapErrorIf"}), err // want ".*RPC method PhiUnwrapErrorIf returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// PhiAllWrapErrorSwitch returns error its sources are all wrap error
+func (app *App) PhiAllWrapErrorSwitch(_ context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want PhiAllWrapErrorSwitch:"okFunc"
+	var err error
+	switch req.Msg.text {
+	case "hello":
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error 1"))
+	default:
+		err = connect.NewError(connect.CodeNotFound, errors.New("wrap error 2"))
+	}
+	return connect.NewResponse(&Message{"PhiAllWrapErrorSwitch"}), err
+}
+
+// PhiUnwrapErrorSwitch returns error its sources contain unwrap error
+func (app *App) PhiUnwrapErrorSwitch(_ context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want PhiUnwrapErrorSwitch:"badFunc" ".*RPC method PhiUnwrapErrorSwitch returns error.*"
+	var err error
+	switch req.Msg.text {
+	case "hello":
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error"))
+	default:
+		err = errors.New("unwrap error")
+	}
+	return connect.NewResponse(&Message{"PhiUnwrapErrorSwitch"}), err // want ".*RPC method PhiUnwrapErrorSwitch returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// NestedPhiUnwrapError returns error its sources contain unwrap error
+func (app *App) NestedPhiUnwrapError(_ context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want NestedPhiUnwrapError:"badFunc" ".*RPC method NestedPhiUnwrapError returns error.*"
+	var err error
+	if req.Msg.text == "hello" {
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error"))
+	} else {
+		err = errors.New("unwrap error")
+	}
+
+	switch req.Msg.text {
+	case "world":
+		err = connect.NewError(connect.CodeInternal, errors.New("wrap error"))
+	}
+	return connect.NewResponse(&Message{"PhiUnwrapErrorIf"}), err // want ".*RPC method NestedPhiUnwrapError returns error.*"
+}

--- a/passes/wraperr/testdata/src/a/a03interface/interfacemethod.go
+++ b/passes/wraperr/testdata/src/a/a03interface/interfacemethod.go
@@ -1,0 +1,37 @@
+package a
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+type handler interface {
+	Handle() error
+}
+
+type App struct {
+	handler handler
+}
+
+type Message struct {
+	text string
+}
+
+// CallInterfaceMethod calls interface's method and returns error directly.
+func (app *App) CallInterfaceMethod(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want CallInterfaceMethod:"badFunc" ".*RPC method CallInterfaceMethod returns error.*"
+	if err := app.handler.Handle(); err != nil {
+		return nil, err // want ".*RPC method CallInterfaceMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallInterfaceMethod"}), nil
+}
+
+// CallInterfaceMethod2 calls interface's method and returns error directly.
+func (app *App) CallInterfaceMethod2(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want CallInterfaceMethod2:"badFunc" ".*RPC method CallInterfaceMethod2 returns error.*"
+	fn := app.handler.Handle
+
+	if err := fn(); err != nil {
+		return nil, err // want ".*RPC method CallInterfaceMethod2 returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallInterfaceMethod2"}), nil
+}

--- a/passes/wraperr/testdata/src/a/a04closure/closure.go
+++ b/passes/wraperr/testdata/src/a/a04closure/closure.go
@@ -1,0 +1,47 @@
+package a04closure
+
+// This file contains closure method call.
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+type App struct{}
+
+type Message struct {
+	text string
+}
+
+// ReturnOkClosureError defines closure and returns its result.
+func (app *App) ReturnOkClosureError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnOkClosureError:"okFunc"
+	okClosure := func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("ReturnOkClosureError"))
+	}
+	if err := okClosure(); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&Message{"ReturnOkClosureError"}), nil
+}
+
+// ReturnBadClosureError defines closure and returns its result.
+func (app *App) ReturnBadClosureError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnBadClosureError:"badFunc" ".*RPC method ReturnBadClosureError returns error.*"
+	badClosure := func() error {
+		return errors.New("ReturnBadClosureError")
+	}
+	if err := badClosure(); err != nil {
+		return nil, err // want ".*RPC method ReturnBadClosureError returns error.*"
+	}
+	return connect.NewResponse(&Message{"ReturnBadClosureError"}), nil
+}
+
+// ReturnConstClosureError defines const closure (no body) and returns its result.
+func (app *App) ReturnConstClosureError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnConstClosureError:"badFunc" ".*RPC method ReturnConstClosureError returns error.*"
+	var constFunc func() error
+	if err := constFunc(); err != nil {
+		return nil, err // want ".*RPC method ReturnConstClosureError returns error.*"
+	}
+	return connect.NewResponse(&Message{"ReturnConstClosureError"}), nil
+}

--- a/passes/wraperr/testdata/src/a/a05global/global.go
+++ b/passes/wraperr/testdata/src/a/a05global/global.go
@@ -1,0 +1,31 @@
+package a05global
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+var (
+	globalErr  error
+	globalFunc func() error
+)
+
+type App struct{}
+
+type Message struct {
+	text string
+}
+
+// ReturnGlobalError returns globalErr
+func (app *App) ReturnGlobalError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnGlobalError:"badFunc" ".*RPC method ReturnGlobalError returns error.*"
+	return nil, globalErr // want ".*RPC method ReturnGlobalError returns error.*"
+}
+
+// CallGlobalFunc calls globalFunc and returns its error.
+func (app *App) CallGlobalFunc(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want CallGlobalFunc:"badFunc" ".*RPC method CallGlobalFunc returns error.*"
+	if err := globalFunc(); err != nil {
+		return nil, err // want ".*RPC method CallGlobalFunc returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallGlobalFunc"}), nil
+}

--- a/passes/wraperr/testdata/src/a/a06parameter/parameter.go
+++ b/passes/wraperr/testdata/src/a/a06parameter/parameter.go
@@ -1,0 +1,17 @@
+package a06parameter
+
+type App struct{}
+
+type Message struct {
+	text string
+}
+
+// returnParamErr returns err its source is parameter.
+func (app *App) returnParamErr(err error) error { // want returnParamErr:"badFunc"
+	return err
+}
+
+// returnParamFunc returns func its source is parameter.
+func (app *App) returnParamFunc(fn func() error) func() error { // want returnParamFunc:"badFunc"
+	return fn
+}

--- a/passes/wraperr/testdata/src/a/a07generics/generics.go
+++ b/passes/wraperr/testdata/src/a/a07generics/generics.go
@@ -1,0 +1,74 @@
+package a07generics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+)
+
+type handler[T any] interface {
+	Handle(in *T) error
+}
+
+type App[T any] struct {
+	handler handler[T]
+}
+
+type Message struct {
+	text string
+}
+
+// ReturnNil returns nil
+func (app *App[T]) ReturnNil(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnNil:"okFunc"
+	return connect.NewResponse(&Message{"ReturnNil"}), nil
+}
+
+// ReturnWrapError returns connect.NewError
+func (app *App[T]) ReturnWrapError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnWrapError:"okFunc"
+	return nil, connect.NewError(connect.CodeInternal, errors.New("ReturnWrapError"))
+}
+
+// ReturnUnwrapError returns unwrap error
+func (app *App[T]) ReturnUnwrapError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want ReturnUnwrapError:"badFunc"  ".*RPC method ReturnUnwrapError returns error.*"
+	return nil, errors.New("ReturnUnwrapError") // want ".*RPC method ReturnUnwrapError returns error.*"
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// CallReturnUnwrapError returns unwrap error
+func (app *App[T]) CallReturnUnwrapError(ctx context.Context, req *connect.Request[Message]) (*connect.Response[Message], error) { // want CallReturnUnwrapError:"badFunc"  ".*RPC method CallReturnUnwrapError returns error.*"
+	return app.ReturnUnwrapError(ctx, req) // want ".*RPC method CallReturnUnwrapError returns error.*"
+}
+
+// CallGenericsInterfaceMethod returns unwrap error
+func (app *App[T]) CallGenericsInterfaceMethod(ctx context.Context, req *connect.Request[T]) (*connect.Response[Message], error) { // want CallGenericsInterfaceMethod:"badFunc"  ".*RPC method CallGenericsInterfaceMethod returns error.*"
+	if err := app.handler.Handle(req.Msg); err != nil {
+		return nil, err // want ".*RPC method CallGenericsInterfaceMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallGenericsInterfaceMethod"}), nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// CallComplexMethodError returns unwrap error
+func (app *App[T]) CallComplexMethodError(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want CallComplexMethodError:"badFunc"  ".*RPC method CallComplexMethodError returns error.*"
+	var m map[string]int
+	_, err := Reversed(m)
+	if err != nil {
+		return nil, err // want ".*RPC method CallComplexMethodError returns error.*"
+	}
+	return connect.NewResponse(&Message{"CallComplexMethodError"}), nil
+}
+
+func Reversed[K, V comparable](original map[K]V) (map[V]K, error) { // want Reversed:"badFunc"
+	reversed := make(map[V]K)
+	for key, value := range original {
+		if _, ok := reversed[value]; ok {
+			return nil, fmt.Errorf("duplicate value found: %v", value)
+		}
+		reversed[value] = key
+	}
+	return reversed, nil
+}

--- a/passes/wraperr/testdata/src/a/a08import/a/a.go
+++ b/passes/wraperr/testdata/src/a/a08import/a/a.go
@@ -1,0 +1,18 @@
+package a
+
+import (
+	"a/a08import/excludedpkg"
+	"a/a08import/includedpkg"
+)
+
+func CallIncludedOKFunc() error { // want CallIncludedOKFunc:"okFunc"
+	return includedpkg.OKFunc()
+}
+
+func CallIncludedBadFunc() error { // want CallIncludedBadFunc:"badFunc"
+	return includedpkg.BadFunc()
+}
+
+func CallExcludedOKFunc() error { // want CallExcludedOKFunc:"badFunc"
+	return excludedpkg.OKFunc()
+}

--- a/passes/wraperr/testdata/src/a/a08import/excludedpkg/excludedpkg.go
+++ b/passes/wraperr/testdata/src/a/a08import/excludedpkg/excludedpkg.go
@@ -1,0 +1,5 @@
+package excludedpkg
+
+func OKFunc() error {
+	return nil
+}

--- a/passes/wraperr/testdata/src/a/a08import/includedpkg/includedpkg.go
+++ b/passes/wraperr/testdata/src/a/a08import/includedpkg/includedpkg.go
@@ -1,0 +1,13 @@
+package includedpkg
+
+import (
+	"errors"
+)
+
+func OKFunc() error { // want OKFunc:"okFunc"
+	return nil
+}
+
+func BadFunc() error { // want BadFunc:"badFunc"
+	return errors.New("BadFunc")
+}

--- a/passes/wraperr/testdata/src/a/a09cyclic/cyclic.go
+++ b/passes/wraperr/testdata/src/a/a09cyclic/cyclic.go
@@ -1,0 +1,76 @@
+package a09cyclic
+
+import (
+	"connectrpc.com/connect"
+	"errors"
+)
+
+// ReachWrapError1 and ReachWrapError2 call each other. It eventually returns wrap error.
+func ReachWrapError1(x int) error { // want ReachWrapError1:"okFunc"
+	if x == 0 {
+		return connect.NewError(connect.CodeInternal, errors.New("x is 0"))
+	}
+	return ReachWrapError2(x - 1)
+}
+
+func ReachWrapError2(x int) error { // want ReachWrapError2:"okFunc"
+	if x == 0 {
+		return connect.NewError(connect.CodeInternal, errors.New("x is 0"))
+	}
+	return ReachWrapError1(x - 1)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// ReachUnwrapError1 and ReachUnwrapError2 call each other. It eventually returns unwrap error.
+func ReachUnwrapError1(x int) error { // want ReachUnwrapError1:"badFunc"
+	if x == 0 {
+		return errors.New("unwrap err")
+	}
+	return ReachUnwrapError2(x - 1)
+}
+
+func ReachUnwrapError2(x int) error { // want ReachUnwrapError2:"badFunc"
+	if x == 0 {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	}
+	return ReachUnwrapError1(x - 1)
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Infinite1 and Infinite2 call each other. It makes infinite loop.
+// Since both don't return unwrap error, the wraperr consider they are okFunc.
+func Infinite1() error { // want Infinite1:"okFunc"
+	return Infinite2()
+}
+
+func Infinite2() error { // want Infinite2:"okFunc"
+	return Infinite1()
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// SelfInfinite makes self infinite loop.
+// Since SelfInfinite doesn't return unwrap error, the wraperr consider it is okFunc.
+func SelfInfinite() error { // want SelfInfinite:"okFunc"
+	return SelfInfinite()
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// NoCyclicErrorRelation1 and NoCyclicErrorRelation2 call each other.
+// But both wrap error with connect.NewError, then the wraperr doesn't put then inside the same SCC.
+func NoCyclicErrorRelation1(x int) error { // want NoCyclicErrorRelation1:"okFunc"
+	if err := NoCyclicErrorRelation2(x - 1); err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	return nil
+}
+
+func NoCyclicErrorRelation2(x int) error { // want NoCyclicErrorRelation2:"okFunc"
+	if err := NoCyclicErrorRelation1(x - 1); err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	return nil
+}

--- a/passes/wraperr/testdata/src/a/go.mod
+++ b/passes/wraperr/testdata/src/a/go.mod
@@ -1,0 +1,7 @@
+module a
+
+go 1.23.6
+
+require connectrpc.com/connect v1.18.1
+
+require google.golang.org/protobuf v1.36.5 // indirect

--- a/passes/wraperr/testdata/src/a/go.sum
+++ b/passes/wraperr/testdata/src/a/go.sum
@@ -1,0 +1,10 @@
+connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
+connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/passes/wraperr/testdata/src/eg/eg01core/eg.go
+++ b/passes/wraperr/testdata/src/eg/eg01core/eg.go
@@ -1,0 +1,272 @@
+package eg01core
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"errors"
+	"golang.org/x/sync/errgroup"
+)
+
+type handler interface {
+	Handle() error
+}
+type App struct {
+	handler handler
+}
+
+type Message struct {
+	text string
+}
+
+// GoOKFuncs calls OK funcs in eg.Go and returns eg.Wait error
+func (app *App) GoOKFuncs(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoOKFuncs:"okFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(func() error {
+		return nil
+	})
+	eg.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	eg.Go(app.ReturnWrapError)
+	eg.Go(app.ReturnReturnWrapError())
+	eg.Go(app.ReturnReturnReturnWrapError()())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&Message{"GoOKFuncs"}), nil
+}
+
+func (app *App) ReturnWrapError() error { // want ReturnWrapError:"okFunc"
+	return connect.NewError(connect.CodeInternal, errors.New("ReturnWrapError"))
+}
+
+func (app *App) ReturnReturnWrapError() func() error { // want ReturnReturnWrapError:"okFunc"
+	return app.ReturnWrapError
+}
+
+func (app *App) ReturnReturnReturnWrapError() func() func() error { // want ReturnReturnReturnWrapError:"okFunc"
+	return app.ReturnReturnWrapError
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoBadClosure calls bad closure in eg.Go and returns eg.Wait error
+func (app *App) GoBadClosure(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoBadClosure:"badFunc" ".*RPC method GoBadClosure returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(func() error {
+		return errors.New("unwrap err")
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoBadClosure returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoBadClosure"}), nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoBadMethod calls bad member method in eg.Go and returns eg.Wait error
+func (app *App) GoBadMethod(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoBadMethod:"badFunc" ".*RPC method GoBadMethod returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnUnwrapError)
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoBadMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoBadMethod"}), nil
+}
+
+func (app *App) ReturnUnwrapError() error { // want ReturnUnwrapError:"badFunc"
+	return errors.New("ReturnUnwrapError")
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoNestedBadMethod calls bad member method in eg.Go and returns eg.Wait error
+func (app *App) GoNestedBadMethod(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoNestedBadMethod:"badFunc" ".*RPC method GoNestedBadMethod returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnReturnUnwrapError())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoNestedBadMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoNestedBadMethod"}), nil
+}
+
+func (app *App) ReturnReturnUnwrapError() func() error { // want ReturnReturnUnwrapError:"badFunc"
+	return func() error {
+		return errors.New("ReturnReturnUnwrapError")
+	}
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoNestedBadMethod2 calls bad member method in eg.Go and returns eg.Wait error
+func (app *App) GoNestedBadMethod2(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoNestedBadMethod2:"badFunc" ".*RPC method GoNestedBadMethod2 returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnReturnReturnUnwrapError()())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoNestedBadMethod2 returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoNestedBadMethod2"}), nil
+}
+
+func (app *App) ReturnReturnReturnUnwrapError() func() func() error { // want ReturnReturnReturnUnwrapError:"badFunc"
+	return app.ReturnReturnUnwrapError
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// NoGoCall returns eg.Wait error but there is no eg.Go call.
+// TODO: this should be treated as okFunc.
+func (app *App) NoGoCall(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want NoGoCall:"badFunc" ".*RPC method NoGoCall returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method NoGoCall returns error.*"
+	}
+	return connect.NewResponse(&Message{"NoGoCall"}), nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Infinite1 and Infinite2 call each other. It makes infinite loop.
+// Since both don't return unwrap error, the wraperr consider they are okFunc.
+func (app *App) Infinite1() error { // want Infinite1:"okFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+	eg.Go(app.Infinite2)
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (app *App) Infinite2() error { // want Infinite2:"okFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+	eg.Go(app.Infinite1)
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// MultiOKOK calls eg.Wait two times with different eg1 and eg2.
+// Both eg1 and eg2 Wait's errors are wrap error.
+func (app *App) MultiOKOK(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want MultiOKOK:"okFunc"
+	eg1, _ := errgroup.WithContext(context.Background())
+	eg1.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	if err := eg1.Wait(); err != nil {
+		return nil, err
+	}
+
+	eg2, _ := errgroup.WithContext(context.Background())
+	eg2.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	if err := eg2.Wait(); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&Message{"MultiOKOK"}), nil
+}
+
+// MultiOKBad calls eg.Wait two times with different eg1 and eg2.
+// Only eg2.Wait's error is unwrap error.
+func (app *App) MultiOKBad(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want MultiOKBad:"badFunc" ".*RPC method MultiOKBad returns error.*"
+	eg1, _ := errgroup.WithContext(context.Background())
+	eg1.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	if err := eg1.Wait(); err != nil {
+		return nil, err
+	}
+
+	eg2, _ := errgroup.WithContext(context.Background())
+	eg2.Go(func() error {
+		return errors.New("unwrap err")
+	})
+	if err := eg2.Wait(); err != nil {
+		return nil, err // want ".*RPC method MultiOKBad returns error.*"
+	}
+
+	return connect.NewResponse(&Message{"MultiOKOK"}), nil
+}
+
+// MultiBadOK calls eg.Wait two times with different eg1 and eg2.
+// Only eg1.Wait's error is unwrap error.
+func (app *App) MultiBadOK(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want MultiBadOK:"badFunc" ".*RPC method MultiBadOK returns error.*"
+	eg1, _ := errgroup.WithContext(context.Background())
+	eg1.Go(func() error {
+		return errors.New("unwrap err")
+	})
+	if err := eg1.Wait(); err != nil {
+		return nil, err // want ".*RPC method MultiBadOK returns error.*"
+	}
+
+	eg2, _ := errgroup.WithContext(context.Background())
+	eg2.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	if err := eg2.Wait(); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&Message{"MultiBadOK"}), nil
+}
+
+// MultiBadBad calls eg.Wait two times with different eg1 and eg2.
+// Both eg1 and eg2 Wait's errors are unwrap error.
+func (app *App) MultiBadBad(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want MultiBadBad:"badFunc" ".*RPC method MultiBadBad returns error.*"
+	eg1, _ := errgroup.WithContext(context.Background())
+	eg1.Go(func() error {
+		return errors.New("unwrap err")
+	})
+	if err := eg1.Wait(); err != nil {
+		return nil, err // want ".*RPC method MultiBadBad returns error.*"
+	}
+
+	eg2, _ := errgroup.WithContext(context.Background())
+	eg2.Go(func() error {
+		return errors.New("unwrap err")
+	})
+	if err := eg2.Wait(); err != nil {
+		return nil, err // want ".*RPC method MultiBadBad returns error.*"
+	}
+
+	return connect.NewResponse(&Message{"MultiBadBad"}), nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// PhiEgErrors return err, this error has multiple eg.Wait sources.
+func (app *App) PhiEgErrors(ctx context.Context, req *connect.Request[string]) (*connect.Response[Message], error) { // want PhiEgErrors:"badFunc" ".*RPC method PhiEgErrors returns error.*"
+	eg1, _ := errgroup.WithContext(context.Background())
+	eg1.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	err1 := eg1.Wait()
+
+	eg2, _ := errgroup.WithContext(context.Background())
+	eg2.Go(func() error {
+		return errors.New("unwrap error")
+	})
+	err2 := eg2.Wait()
+
+	var err error
+	if req.Msg == nil {
+		err = err1
+	} else {
+		err = err2
+	}
+	return nil, err // want ".*RPC method PhiEgErrors returns error.*"
+}

--- a/passes/wraperr/testdata/src/eg/eg02generics/generics.go
+++ b/passes/wraperr/testdata/src/eg/eg02generics/generics.go
@@ -1,0 +1,136 @@
+package generics
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	"golang.org/x/sync/errgroup"
+)
+
+type handler[T any] interface {
+	Handle() error
+}
+
+type App[T any] struct {
+	handler handler[T]
+}
+
+type Message struct {
+	text string
+}
+
+// GoOKFuncs calls OK funcs in eg.Go and returns eg.Wait error
+func (app *App[T]) GoOKFuncs(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoOKFuncs:"okFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(func() error {
+		return nil
+	})
+	eg.Go(func() error {
+		return connect.NewError(connect.CodeInternal, errors.New("wrap err"))
+	})
+	eg.Go(app.ReturnWrapError)
+	eg.Go(app.ReturnReturnWrapError())
+	eg.Go(app.ReturnReturnReturnWrapError()())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&Message{"GoOKFuncs"}), nil
+}
+
+func (app *App[T]) ReturnWrapError() error { // want ReturnWrapError:"okFunc"
+	return connect.NewError(connect.CodeInternal, errors.New("ReturnWrapError"))
+}
+
+func (app *App[T]) ReturnReturnWrapError() func() error { // want ReturnReturnWrapError:"okFunc"
+	return app.ReturnWrapError
+}
+
+func (app *App[T]) ReturnReturnReturnWrapError() func() func() error { // want ReturnReturnReturnWrapError:"okFunc"
+	return app.ReturnReturnWrapError
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoBadClosure calls bad closure in eg.Go and returns eg.Wait error
+func (app *App[T]) GoBadClosure(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoBadClosure:"badFunc" ".*RPC method GoBadClosure returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(func() error {
+		return errors.New("unwrap err")
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoBadClosure returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoBadClosure"}), nil
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoBadMethod calls bad member method in eg.Go and returns eg.Wait error
+func (app *App[T]) GoBadMethod(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoBadMethod:"badFunc" ".*RPC method GoBadMethod returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnUnwrapError)
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoBadMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoBadMethod"}), nil
+}
+
+func (app *App[T]) ReturnUnwrapError() error { // want ReturnUnwrapError:"badFunc"
+	return errors.New("ReturnUnwrapError")
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoNestedBadMethod calls bad member method in eg.Go and returns eg.Wait error
+func (app *App[T]) GoNestedBadMethod(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoNestedBadMethod:"badFunc" ".*RPC method GoNestedBadMethod returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnReturnUnwrapError())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoNestedBadMethod returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoNestedBadMethod"}), nil
+}
+
+func (app *App[T]) ReturnReturnUnwrapError() func() error { // want ReturnReturnUnwrapError:"badFunc"
+	return func() error {
+		return errors.New("ReturnReturnUnwrapError")
+	}
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// GoNestedBadMethod2 calls bad member method in eg.Go and returns eg.Wait error
+func (app *App[T]) GoNestedBadMethod2(_ context.Context, _ *connect.Request[Message]) (*connect.Response[Message], error) { // want GoNestedBadMethod2:"badFunc" ".*RPC method GoNestedBadMethod2 returns error.*"
+	eg, _ := errgroup.WithContext(context.Background())
+
+	eg.Go(app.ReturnReturnReturnUnwrapError()())
+
+	if err := eg.Wait(); err != nil {
+		return nil, err // want ".*RPC method GoNestedBadMethod2 returns error.*"
+	}
+	return connect.NewResponse(&Message{"GoNestedBadMethod2"}), nil
+}
+
+func (app *App[T]) ReturnReturnReturnUnwrapError() func() func() error { // want ReturnReturnReturnUnwrapError:"badFunc"
+	return app.ReturnReturnUnwrapError
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+//func (app *App[T]) CallInterfaceMethod() error { //  CallInterfaceMethod:"badFunc" ".*RPC method CallInterfaceMethod returns error.*"
+//	eg, _ := errgroup.WithContext(context.Background())
+//	eg.Go(app.handler.Handle)
+//	if err := eg.Wait(); err != nil {
+//		return err //  ".*RPC method CallInterfaceMethod returns error.*"
+//	}
+//	return nil
+//}

--- a/passes/wraperr/testdata/src/eg/eg03interface/interfacemethod.go
+++ b/passes/wraperr/testdata/src/eg/eg03interface/interfacemethod.go
@@ -1,0 +1,37 @@
+package eg03interface
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type handler interface {
+	Handle() error
+}
+type App struct {
+	handler handler
+}
+
+type Message struct {
+	text string
+}
+
+func (app *App) CallInterfaceMethod() error { // want CallInterfaceMethod:"badFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+	eg.Go(app.handler.Handle)
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (app *App) CallInterfaceMethod2() error { // want CallInterfaceMethod2:"badFunc"
+	eg, _ := errgroup.WithContext(context.Background())
+	fn := app.handler.Handle
+	eg.Go(fn)
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/passes/wraperr/testdata/src/eg/go.mod
+++ b/passes/wraperr/testdata/src/eg/go.mod
@@ -1,0 +1,10 @@
+module eg
+
+go 1.23.4
+
+require (
+	connectrpc.com/connect v1.18.1
+	golang.org/x/sync v0.11.0
+)
+
+require google.golang.org/protobuf v1.36.5 // indirect

--- a/passes/wraperr/testdata/src/eg/go.sum
+++ b/passes/wraperr/testdata/src/eg/go.sum
@@ -1,0 +1,12 @@
+connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
+connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/passes/wraperr/visitors/call2func/visitor.go
+++ b/passes/wraperr/visitors/call2func/visitor.go
@@ -1,0 +1,40 @@
+package call2func
+
+import (
+	"errors"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+)
+
+type visitorPlugin struct {
+	ret *ssa.Function
+}
+
+func (p *visitorPlugin) VisitFunction(val *ssa.Function) error {
+	if p.ret != nil {
+		return errors.New("unexpected ret is not nil")
+	}
+	p.ret = val
+	return nil
+}
+
+func (p *visitorPlugin) createOptions() []ssawalk.Option {
+	return []ssawalk.Option{
+		ssawalk.WithVisitFunction(p.VisitFunction),
+	}
+}
+
+func GetFuncFromCall(value ssa.Value) (*ssa.Function, error) {
+	plugin := &visitorPlugin{}
+	visitor := ssawalk.NewDefaultVisitorWith(plugin.createOptions()...)
+	if err := ssawalk.Walk(visitor, value); err != nil {
+		return nil, err
+	}
+	if plugin.ret == nil {
+		// srcFnc calls func that is not able to analyze like func in parameter.
+		return nil, nil
+	}
+	return plugin.ret, nil
+}

--- a/passes/wraperr/visitors/norm/norm.go
+++ b/passes/wraperr/visitors/norm/norm.go
@@ -1,0 +1,26 @@
+package norm
+
+import (
+	"golang.org/x/tools/go/ssa"
+)
+
+func NewNormalizeFunc(indices []int) func(fn *ssa.Function) (*ssa.Function, error) {
+	return func(fn *ssa.Function) (*ssa.Function, error) {
+		return normalize(fn, indices)
+	}
+}
+
+func normalize(fn *ssa.Function, indices []int) (*ssa.Function, error) {
+	normed, err := unbind(fn)
+	if err != nil {
+		return nil, err
+	}
+	if normed == nil {
+		return nil, nil
+	}
+	normed, err = uninstantiate(normed, indices)
+	if err != nil {
+		return nil, err
+	}
+	return normed, nil
+}

--- a/passes/wraperr/visitors/norm/unbind.go
+++ b/passes/wraperr/visitors/norm/unbind.go
@@ -1,0 +1,70 @@
+package norm
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// This file contains bounded method wrapper support.
+// Below sample code,
+// Hello() method returns `a.hi`.
+// Since it has receiver "a", a.hi here is bound method wrapper for `a.hi` by synthetic function.
+// Unbind() unbinds and return original `a.hi`.
+/**
+type A struct{}
+
+func (a *A) Hello() func() error {
+	return a.hi // (1) this a.hi is `(*A).hi$bound`, we want to get `(*A).hi` so that we can match with (2)
+}
+
+func (a *A) hi() error { // (2) this hi is `(*A).hi`
+	return nil
+}
+**/
+
+// unbind unbinds wrapper func and return original func.
+// If fn is not wrapper func returns fn itself.
+func unbind(fn *ssa.Function) (*ssa.Function, error) {
+	if !isWrapper(fn) {
+		return fn, nil
+	}
+	return unwrap(fn)
+}
+
+// unwrap returns a function that is wrapped by wrapperFunc.
+func unwrap(wrapperFunc *ssa.Function) (*ssa.Function, error) {
+	if len(wrapperFunc.Blocks) != 1 {
+		panic(fmt.Sprintf("unexpected wrapper func (len(Blocks) != 1) %v", wrapperFunc.Name()))
+	}
+	block := wrapperFunc.Blocks[0]
+	if len(block.Instrs) < 2 {
+		// Instrs should be Call, (Extract,.., Extract), Return.
+		panic(fmt.Sprintf("unexpected wrapper func (len(Instrs) != 2) %v", wrapperFunc.Name()))
+	}
+	call, ok := block.Instrs[0].(*ssa.Call)
+	if !ok {
+		panic(fmt.Sprintf("unexpected wrapper func (Instrs[0] != *ssa.Call) %v", wrapperFunc.Name()))
+	}
+	if call.Call.IsInvoke() {
+		// eg.Go calls interface method
+		return wrapperFunc, nil
+	}
+	fn, ok := call.Call.Value.(*ssa.Function)
+	if !ok {
+		panic(fmt.Sprintf("unexpected wrapper func (Call.Value != *ssa.Function) %v", wrapperFunc.Name()))
+	}
+	return fn, nil
+}
+
+// isWrapper returns true if fn is a bound method wrapper for some other func.
+func isWrapper(fn *ssa.Function) bool {
+	if fn.Synthetic == "" {
+		return false
+	}
+	if strings.HasPrefix(fn.Synthetic, "bound method wrapper for ") {
+		return true
+	}
+	return false
+}

--- a/passes/wraperr/visitors/norm/uninstantiate.go
+++ b/passes/wraperr/visitors/norm/uninstantiate.go
@@ -1,0 +1,61 @@
+package norm
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/errtrace/ssawalk"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/rtn"
+)
+
+type visitorPlugin struct {
+	ret *ssa.Function
+}
+
+func (p *visitorPlugin) VisitFunction(val *ssa.Function) error {
+	if p.ret != nil {
+		return errors.New("unexpected ret is not nil")
+	}
+	p.ret = val
+	return nil
+}
+
+func (p *visitorPlugin) createOptions() []ssawalk.Option {
+	return []ssawalk.Option{
+		ssawalk.WithVisitFunction(p.VisitFunction),
+		ssawalk.WithVisitConst(func(_ *ssa.Const) error {
+			panic("unexpected const")
+		}),
+		ssawalk.WithVisitAlloc(func(_ *ssa.Alloc) error {
+			panic("unexpected alloc")
+		}),
+		ssawalk.WithVisitComplex(func(_ ssa.Value) error {
+			panic("unexpected complex")
+		}),
+		ssawalk.WithVisitCallInvoke(func(_ *ssa.Call) error {
+			panic("unexpected call invoke")
+		}),
+	}
+}
+
+func uninstantiate(fn *ssa.Function, indices []int) (*ssa.Function, error) {
+	if !strings.HasPrefix(fn.Synthetic, "instantiation wrapper of ") {
+		// return given fn.
+		return fn, nil
+	}
+	plugin := &visitorPlugin{}
+	visitor := ssawalk.NewDefaultVisitorWith(plugin.createOptions()...)
+	for _, val := range rtn.GetReturnsAt(fn, indices) {
+		if err := ssawalk.Walk(visitor, val.Value); err != nil {
+			return nil, err
+		}
+	}
+	if plugin.ret == nil {
+		return nil, fmt.Errorf("unexpected: walk fail to unwrap function %v", fn.Name())
+	}
+	return plugin.ret, nil
+}

--- a/passes/wraperr/wraperr.go
+++ b/passes/wraperr/wraperr.go
@@ -1,0 +1,237 @@
+package wraperr
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/cloverrose/rpcguard/pkg/factutil"
+	"github.com/cloverrose/rpcguard/pkg/filter"
+	"github.com/cloverrose/rpcguard/pkg/graph"
+	"github.com/cloverrose/rpcguard/pkg/logger"
+	"github.com/cloverrose/rpcguard/pkg/rpcmethod"
+	"github.com/cloverrose/rpcguard/pkg/signature"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr/callgraph"
+	"github.com/cloverrose/rpcguard/passes/wraperr/callgraph/plugin/eg"
+)
+
+const (
+	doc               = "rpc_wraperr checks if errors returned in RPC method is wrapped by connect.NewError."
+	reportMsg         = "RPC method %s returns error that is not wrapped with connect.NewError"
+	packageKey        = "package"
+	unexpectedUnknown = "unexpected KindUnknown"
+)
+
+// Analyzer checks if RPC method returns error properly.
+var Analyzer = &analysis.Analyzer{
+	Name: "rpc_wraperr",
+	Doc:  doc,
+	Run:  setupAndRun,
+	Requires: []*analysis.Analyzer{
+		buildssa.Analyzer,
+	},
+	Flags: *flag.NewFlagSet("rpc_wraperr", flag.ExitOnError),
+	FactTypes: []analysis.Fact{
+		&isErrorHandler{},
+	},
+}
+
+func init() {
+	Analyzer.Flags.StringVar(&LogLevel, "LogLevel", LogLevel, "logging level")
+	Analyzer.Flags.StringVar(&ReportMode, "ReportMode", ReportMode, "reporting mode (RETURN, FUNCTION, BOTH)")
+	Analyzer.Flags.StringVar(&IncludePackages, "IncludePackages", IncludePackages, "include packages")
+	Analyzer.Flags.StringVar(&ExcludePackages, "ExcludePackages", ExcludePackages, "exclude packages")
+	Analyzer.Flags.StringVar(&ExcludeFiles, "ExcludeFiles", ExcludeFiles, "exclude files")
+	Analyzer.Flags.BoolVar(&EnableErrGroupAnalyzer, "EnableErrGroupAnalyzer", EnableErrGroupAnalyzer, "enable ErrGroupAnalyzer (default true)")
+}
+
+func setupAndRun(pass *analysis.Pass) (interface{}, error) {
+	slog.SetDefault(logger.NewLogger(logger.ConvertLogLevel(LogLevel), pass))
+
+	var err error
+	packageFilter, err = filter.New(IncludePackages, ExcludePackages)
+	if err != nil {
+		return nil, err
+	}
+
+	// any files that are not excluded are target.
+	fileFilter, err = filter.New(`.*`, ExcludeFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return run(pass)
+}
+
+//nolint:gocognit,gocyclo,cyclop // main routine
+func run(pass *analysis.Pass) (interface{}, error) {
+	currentPackage := pass.Pkg.Path()
+	slog.Debug("analyzing package", slog.String(packageKey, currentPackage))
+
+	// Phase1: Package is target?
+	if !packageFilter.IsTarget(currentPackage) {
+		slog.Debug("skip package (not target package)", slog.String(packageKey, currentPackage))
+		return nil, nil
+	}
+
+	// Phase 2: Get SSA
+	ssaData, ok := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+	if !ok {
+		panic("failed to get SSA")
+	}
+
+	// Phase 3: Func is target?
+	targetSrcFuncs := make([]*ssa.Function, 0, len(ssaData.SrcFuncs))
+	for _, srcFunc := range ssaData.SrcFuncs {
+		if isTargetFunc(pass, srcFunc) {
+			targetSrcFuncs = append(targetSrcFuncs, srcFunc)
+		}
+	}
+
+	// Phase 4: Build Call Graph
+	cg := callgraph.New(signature.ErrIshIndices)
+	for _, srcFunc := range targetSrcFuncs {
+		if err := cg.Scan(srcFunc); err != nil {
+			return nil, err
+		}
+	}
+	slog.Debug("build callgraph", slog.Any("callgraph", cg))
+
+	// Phase 5: Analyze go.Wait and go.Go
+	if EnableErrGroupAnalyzer {
+		for _, srcFunc := range targetSrcFuncs {
+			if err := cg.ScanWithPlugin(eg.Scan, srcFunc); err != nil {
+				return nil, err
+			}
+		}
+		slog.Debug("build callgraph with errgroup", slog.Any("callgraph", cg))
+	}
+
+	// closure func (ends with $1) Object() == nil, then we can't export facts.
+	// Thus, use this localFacts during package check.
+	factWrapper := factutil.NewFactWrapper[*isErrorHandler](pass)
+
+	// Phase 6: Export obvious facts.
+	for _, srcFunc := range targetSrcFuncs {
+		info := cg.GetReturnInfo(srcFunc)
+		if info == nil {
+			panic(fmt.Sprintf("unexpected info not found for srcFunc: %s", srcFunc.Name()))
+		}
+		if info.IsObviouslyBad() {
+			factWrapper.Export(srcFunc, &isErrorHandler{Kind: KindBad})
+		}
+		if info.IsObviouslyOK() {
+			factWrapper.Export(srcFunc, &isErrorHandler{Kind: KindOK})
+		}
+	}
+
+	// Phase 7: Create SCCs (this sccs are topologically sorted)
+	g := cg.Convert()
+	slog.Debug("build graph", slog.Any("graph", g))
+	sccs := graph.Decomposition(g)
+	slog.Debug("Strongly Connected Components", slog.Any("sccs", sccs))
+
+	if err := markSCCs(pass, sccs, factWrapper, cg); err != nil {
+		return nil, err
+	}
+
+	// Phase 8: Check RPC method is marked with bad or not.
+	rpcChecker := rpcmethod.BuildChecker(pass)
+	if rpcChecker == nil {
+		slog.Debug("skip package (no rpc method types)", slog.String(packageKey, currentPackage))
+		return nil, nil
+	}
+	for _, fn := range targetSrcFuncs {
+		if !rpcChecker.IsRPCMethod(fn) {
+			continue
+		}
+		slog.Info("found RPC method", logger.Attr(fn))
+
+		fact, ok := factWrapper.Import(fn)
+		if ok {
+			switch fact.Kind {
+			case KindUnknown:
+				panic(unexpectedUnknown)
+			case KindBad:
+				if ReportMode == reportModeFunction || ReportMode == reportModeBoth {
+					pass.Reportf(fn.Pos(), reportMsg, fn.Name())
+				}
+				if ReportMode == reportModeReturn || ReportMode == reportModeBoth {
+					info := cg.GetReturnInfo(fn)
+					for _, rtn := range info.GetReturns() {
+						reportReturn(pass, factWrapper, info, fn, rtn)
+					}
+				}
+			case KindOK:
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func reportReturn(
+	pass *analysis.Pass,
+	factWrapper *factutil.FactWrapper[*isErrorHandler],
+	info *callgraph.FuncInfo,
+	fn *ssa.Function,
+	rtn *ssa.Return,
+) {
+	for _, toFunc := range info.GetToFuncs(rtn) {
+		if fact, ok := factWrapper.Import(toFunc); ok && fact.Kind == KindBad {
+			pass.Reportf(rtn.Pos(), reportMsg, fn.Name())
+			return
+		}
+	}
+	if info.IsObviouslyBadReturn(rtn) {
+		pass.Reportf(rtn.Pos(), reportMsg, fn.Name())
+	}
+}
+
+func isTargetFunc(pass *analysis.Pass, srcFunc *ssa.Function) bool {
+	if srcFunc == nil {
+		panic("srcFunc is nil")
+	}
+	fileName := pass.Fset.Position(srcFunc.Pos()).Filename
+	if srcFunc.Pkg == nil {
+		panic("srcFunc.Pkg is nil")
+	}
+	if srcFunc.Pkg.Pkg == nil {
+		panic("srcFunc.Pkg.Pkg is nil")
+	}
+	if !packageFilter.IsTarget(srcFunc.Pkg.Pkg.Path()) {
+		panic("!packageFilter.IsTarget(srcFunc.Pkg.Pkg.Path())")
+	}
+	if !fileFilter.IsTarget(fileName) {
+		slog.Debug("skip Function (non target file)", logger.Attr(srcFunc))
+		return false
+	}
+
+	// srcFunc signature is not target?
+	indices := signature.ErrIshIndices(srcFunc)
+	return len(indices) != 0
+}
+
+type SCCs [][]*ssa.Function
+
+func (sccs SCCs) LogValue() slog.Value {
+	coreData := make([][]string, len(sccs))
+	for i, scc := range sccs {
+		coreData2 := make([]string, len(scc))
+		for j, fn := range scc {
+			coreData2[j] = fn.String()
+		}
+		coreData[i] = coreData2
+	}
+	jsonBytes, err := json.Marshal(coreData)
+	if err != nil {
+		return slog.Value{}
+	}
+	return slog.StringValue(string(jsonBytes))
+}

--- a/passes/wraperr/wraperr_test.go
+++ b/passes/wraperr/wraperr_test.go
@@ -1,0 +1,25 @@
+package wraperr_test
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/gostaticanalysis/testutil"
+
+	"github.com/cloverrose/rpcguard/passes/wraperr"
+)
+
+func Test(t *testing.T) {
+	t.Parallel()
+	testdata := analysistest.TestData()
+	testdata = testutil.WithModules(t, testdata, nil)
+	wraperr.LogLevel = "INFO"
+	wraperr.ReportMode = "BOTH"
+	wraperr.EnableErrGroupAnalyzer = true
+	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,eg/eg01core,eg/eg02generics,eg/eg03interface"
+	wraperr.IncludePackages = "^(a/a01core|a/a02phi|a/a03interface|a/a04closure|a/a05global|a/a06parameter|a/a07generics|a/a08import/a|a/a08import/includedpkg|a/a09cyclic|eg/eg01core|eg/eg02generics|eg/eg03interface)$"
+	wraperr.ExcludePackages = "(.+/)?vendor$"
+	analysistest.Run(t, testdata, wraperr.Analyzer, strings.Split(pkgs, ",")...)
+}

--- a/pkg/factutil/wrapper.go
+++ b/pkg/factutil/wrapper.go
@@ -1,0 +1,57 @@
+package factutil
+
+import (
+	"fmt"
+	"reflect"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ssa"
+)
+
+type FactWrapper[T analysis.Fact] struct {
+	pass       *analysis.Pass
+	localFacts map[*ssa.Function]T
+}
+
+func NewFactWrapper[T analysis.Fact](pass *analysis.Pass) *FactWrapper[T] {
+	return &FactWrapper[T]{
+		pass:       pass,
+		localFacts: make(map[*ssa.Function]T),
+	}
+}
+
+func (f *FactWrapper[T]) Export(fn *ssa.Function, fact T) {
+	if fn == nil {
+		panic("fn == nil")
+	}
+	if fn.Pkg == nil || fn.Pkg.Pkg == nil || fn.Pkg.Pkg != f.pass.Pkg || fn.Object() == nil {
+		f.localFacts[fn] = fact
+	} else {
+		f.pass.ExportObjectFact(fn.Object(), fact)
+	}
+}
+
+//nolint:ireturn // Need to return interface for generics.
+func (f *FactWrapper[T]) Import(fn *ssa.Function) (T, bool) {
+	if fn == nil {
+		panic("fn == nil")
+	}
+	if lf, ok := f.localFacts[fn]; ok {
+		return lf, true
+	}
+	if fn.Object() == nil {
+		var t T
+		return t, false
+	}
+	var fact T
+	factType := reflect.TypeOf(fact).Elem()
+	factValue, ok := reflect.New(factType).Interface().(T)
+	if !ok {
+		panic(fmt.Sprintf("fact type %s is not T", factType))
+	}
+	if f.pass.ImportObjectFact(fn.Object(), factValue) {
+		return factValue, true
+	}
+	var t T
+	return t, false
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,0 +1,99 @@
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+)
+
+// https://www.logarithmic.net/pfh/blog/01208083168
+
+type Graph[T comparable] struct {
+	Vertices []T
+	Edges    map[T][]T
+}
+
+// NewGraph returns new graph.
+func NewGraph[T comparable]() *Graph[T] {
+	return &Graph[T]{
+		Edges: make(map[T][]T),
+	}
+}
+
+func (g *Graph[T]) AddEdge(start, end T) {
+	if idx := slices.Index(g.Vertices, start); idx == -1 {
+		g.Vertices = append(g.Vertices, start)
+	}
+	if idx := slices.Index(g.Vertices, end); idx == -1 {
+		g.Vertices = append(g.Vertices, end)
+	}
+	if idx := slices.Index(g.Edges[start], end); idx == -1 {
+		g.Edges[start] = append(g.Edges[start], end)
+	}
+}
+
+func (g *Graph[T]) LogValue() slog.Value {
+	coreData := make(map[string][]string)
+	for v, wlist := range g.Edges {
+		coreData2 := make([]string, 0, len(wlist))
+		for _, w := range wlist {
+			coreData2 = append(coreData2, fmt.Sprintf("%v", w))
+		}
+		coreData[fmt.Sprintf("%v", v)] = coreData2
+	}
+	jsonBytes, err := json.Marshal(coreData)
+	if err != nil {
+		return slog.Value{}
+	}
+	return slog.StringValue(string(jsonBytes))
+}
+
+func Decomposition[T comparable](g *Graph[T]) [][]T {
+	index := make(map[T]int)
+	lowLink := make(map[T]int)
+	stack := make([]T, 0)
+	onStack := make(map[T]bool)
+	var currentIndex int
+
+	var result [][]T
+	var strongConnect func(v T)
+	strongConnect = func(v T) {
+		index[v] = currentIndex
+		lowLink[v] = currentIndex
+		currentIndex++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		for _, w := range g.Edges[v] {
+			if _, ok := index[w]; !ok {
+				strongConnect(w)
+				lowLink[v] = min(lowLink[v], lowLink[w])
+			} else if onStack[w] {
+				lowLink[v] = min(lowLink[v], lowLink[w])
+			}
+		}
+
+		if lowLink[v] == index[v] {
+			var w T
+			var scc []T
+			for {
+				w, stack = stack[len(stack)-1], stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			result = append(result, scc)
+		}
+	}
+
+	for _, v := range g.Vertices {
+		if _, ok := index[v]; !ok {
+			strongConnect(v)
+		}
+	}
+
+	return result
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,120 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDecomposition(t *testing.T) {
+	t.Parallel()
+	type testCase[T comparable] struct {
+		name string
+		g    *Graph[T]
+		want [][]T
+	}
+	tests := []testCase[int]{
+		{
+			name: "No SCC",
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(0, 1)
+				return g
+			}(),
+			want: [][]int{{1}, {0}},
+		},
+		{
+			name: "SCC",
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(0, 1)
+				g.AddEdge(1, 0)
+				return g
+			}(),
+			want: [][]int{{1, 0}},
+		},
+		{
+			name: "2 SCC",
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(0, 1)
+				g.AddEdge(1, 0)
+				g.AddEdge(1, 2)
+				return g
+			}(),
+			want: [][]int{{2}, {1, 0}},
+		},
+		{
+			name: "2 SCC",
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(0, 1)
+				g.AddEdge(1, 0)
+				g.AddEdge(1, 2)
+				g.AddEdge(2, 3)
+				g.AddEdge(3, 2)
+				return g
+			}(),
+			want: [][]int{{3, 2}, {1, 0}},
+		},
+		{
+			name: "Complex", //nolint:usestdlibvars // this is not related to constant.Complex.
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(0, 2)
+				g.AddEdge(0, 3)
+				g.AddEdge(1, 5)
+				g.AddEdge(2, 1)
+				g.AddEdge(2, 3)
+				g.AddEdge(3, 0)
+				g.AddEdge(3, 1)
+				g.AddEdge(3, 7)
+				g.AddEdge(4, 6)
+				g.AddEdge(4, 7)
+				g.AddEdge(5, 1)
+				g.AddEdge(5, 8)
+				g.AddEdge(6, 9)
+				g.AddEdge(7, 8)
+				g.AddEdge(7, 9)
+				g.AddEdge(8, 10)
+				g.AddEdge(9, 4)
+				return g
+			}(),
+			want: [][]int{{10}, {8}, {5, 1}, {6, 4, 9, 7}, {3, 2, 0}},
+		},
+		{
+			name: "Complex 2",
+			g: func() *Graph[int] {
+				g := NewGraph[int]()
+				g.AddEdge(7, 8)
+				g.AddEdge(7, 9)
+				g.AddEdge(8, 10)
+				g.AddEdge(3, 1)
+				g.AddEdge(3, 7)
+				g.AddEdge(4, 6)
+				g.AddEdge(4, 7)
+				g.AddEdge(5, 1)
+				g.AddEdge(5, 8)
+				g.AddEdge(0, 2)
+				g.AddEdge(0, 3)
+				g.AddEdge(1, 5)
+				g.AddEdge(2, 1)
+				g.AddEdge(2, 3)
+				g.AddEdge(3, 0)
+				g.AddEdge(6, 9)
+				g.AddEdge(9, 4)
+				return g
+			}(),
+			want: [][]int{{10}, {8}, {6, 4, 9, 7}, {5, 1}, {2, 0, 3}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Decomposition(tt.g)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Decomposition() diff (-want,+got) %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/signature/util.go
+++ b/pkg/signature/util.go
@@ -1,0 +1,42 @@
+package signature
+
+import (
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/gostaticanalysis/analysisutil"
+)
+
+func ErrIshIndices(fn *ssa.Function) []int {
+	sig := fn.Signature
+	retLen := sig.Results().Len()
+	indices := make([]int, 0, retLen)
+	for i := range retLen {
+		v := sig.Results().At(i)
+		if isErrorIsh(v) {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+func isErrorIsh(v *types.Var) bool {
+	if analysisutil.ImplementsError(v.Type()) {
+		return true
+	}
+
+	// higher order function
+	sig, ok := v.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	retLen := sig.Results().Len()
+	for i := range retLen {
+		w := sig.Results().At(i)
+		if isErrorIsh(w) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add new linter `rpc_wraperr` that checks if RPC methods properly wrap errors with `connect.NewError`.

This linter helps ensure that all errors returned from RPC methods are properly wrapped, which is a common requirement for RPC error handling.

Key features:
- Analyzes function call graphs to track error propagation
- Supports errgroup.Group error handling
- Configurable through command line options and golangci-lint settings
- Can report violations at return instruction or function level

The linter is available as:
- A standalone `go vet` tool
- A golangci-lint custom plugin

Implementation details:
- Uses SSA-based analysis to track error values
- Handles bounded method wrappers and generic instantiations
- Supports strongly connected component analysis for recursive calls