### PR TITLE
feat(wraperr): support defer

### DIFF
--- a/passes/wraperr/testdata/src/a/a10defer/defer.go
+++ b/passes/wraperr/testdata/src/a/a10defer/defer.go
@@ -1,0 +1,37 @@
+package a10defer
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+func DeferFuncOKNoName() (string, error) { // want DeferFuncOKNoName:"okFunc"
+	defer func() {}()
+	return "ok", nil
+}
+
+func DeferFuncOKNamed() (x string, err1 error) { // want DeferFuncOKNamed:"okFunc"
+	defer func() {
+		x = "set in defer"
+	}()
+	return "ok", nil
+}
+
+func DeferFuncBad() (x string, err error) { // want DeferFuncBad:"badFunc"
+	defer func() {
+		x = "set in defer"
+		err = errors.New("set in defer")
+	}()
+	return "ok", nil
+}
+
+// DeferFuncBadConnectError has a defer block.
+// err is assigned with connect error but it is treated as badFunc.
+func DeferFuncBadConnectError() (x string, err error) { // want DeferFuncBadConnectError:"badFunc"
+	defer func() {
+		x = "set in defer"
+		err = connect.NewError(connect.CodeInternal, errors.New("set in defer"))
+	}()
+	return "ok", nil
+}

--- a/passes/wraperr/wraperr_test.go
+++ b/passes/wraperr/wraperr_test.go
@@ -18,8 +18,8 @@ func Test(t *testing.T) {
 	wraperr.LogLevel = "INFO"
 	wraperr.ReportMode = "BOTH"
 	wraperr.EnableErrGroupAnalyzer = true
-	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,eg/eg01core,eg/eg02generics,eg/eg03interface"
-	wraperr.IncludePackages = "^(a/a01core|a/a02phi|a/a03interface|a/a04closure|a/a05global|a/a06parameter|a/a07generics|a/a08import/a|a/a08import/includedpkg|a/a09cyclic|eg/eg01core|eg/eg02generics|eg/eg03interface)$"
+	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,a/a10defer,eg/eg01core,eg/eg02generics,eg/eg03interface"
+	wraperr.IncludePackages = "^(a/a01core|a/a02phi|a/a03interface|a/a04closure|a/a05global|a/a06parameter|a/a07generics|a/a08import/a|a/a08import/includedpkg|a/a09cyclic|a/a10defer|eg/eg01core|eg/eg02generics|eg/eg03interface)$"
 	wraperr.ExcludePackages = "(.+/)?vendor$"
 	analysistest.Run(t, testdata, wraperr.Analyzer, strings.Split(pkgs, ",")...)
 }


### PR DESCRIPTION
# What

Support defer.

If func has defer block, defer block triggers ssa.Alloc.
Without this change, func with defer is marked as badFunc.
Ideally, if defer doesn't assign err1, it should not be marked as badFunc.

```go
	func Foo() (x string, err1 error) {
		defer func () {
			x = "set in defer"
		}
		return "ok", nil
	}
```

Note: Even err1 is assigned with wrapped error (`connect.NewError`), `wraperr` marks `Foo` badFunc.