### PR TITLE
fix(wraperr): fix index out of range bug

### DIFF
--- a/passes/wraperr/callgraph/cg.go
+++ b/passes/wraperr/callgraph/cg.go
@@ -48,13 +48,22 @@ func (cg *CallGraph) Scan(srcFunc *ssa.Function) error {
 func scanFunc(fn *ssa.Function, indices []int) (*FuncInfo, error) {
 	data := make(map[*ssa.Return]*returnInfo)
 	for _, val := range rtn.GetReturnsAt(fn, indices) {
-		info, err := scanVal(val.Value, indices)
+		info, err := scanVal(val.Value, getTargetIndex(val.Value))
 		if err != nil {
 			return nil, err
 		}
 		data[val.Return] = info
 	}
 	return &FuncInfo{data: data}, nil
+}
+
+func getTargetIndex(val ssa.Value) []int {
+	switch val := val.(type) {
+	case *ssa.Extract:
+		return []int{val.Index}
+	default:
+		return []int{0}
+	}
 }
 
 // scanVal scans single return value and returns returnInfo.

--- a/passes/wraperr/testdata/src/a/a21returnindex/returnindex.go
+++ b/passes/wraperr/testdata/src/a/a21returnindex/returnindex.go
@@ -1,0 +1,47 @@
+package a21returnindex
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+func ReturnErrorAt3() (string, string, error) { // want ReturnErrorAt3:"okFunc"
+	err := ReturnErrorAt1("hello")
+	if err != nil {
+		return "", "", err
+	}
+	v, err2 := ReturnErrorAt2("hello")
+	if err2 != nil {
+		return "", "", err2
+	}
+	return "ok", v, nil
+}
+
+func ReturnErrorAt1[T any](_ T) error { // want ReturnErrorAt1:"okFunc"
+	return connect.NewError(connect.CodeInternal, errors.New("error at 1"))
+}
+
+func ReturnErrorAt2[T any](_ T) (string, error) { // want ReturnErrorAt2:"okFunc"
+	return "", connect.NewError(connect.CodeInternal, errors.New("error at 2"))
+}
+
+func BadReturnErrorAt3() (string, string, error) { // want BadReturnErrorAt3:"badFunc"
+	err := BadReturnErrorAt1("hello")
+	if err != nil {
+		return "", "", err
+	}
+	v, err2 := BadReturnErrorAt2("hello")
+	if err2 != nil {
+		return "", "", err2
+	}
+	return "ok", v, nil
+}
+
+func BadReturnErrorAt1[T any](_ T) error { // want BadReturnErrorAt1:"badFunc"
+	return errors.New("error at 1")
+}
+
+func BadReturnErrorAt2[T any](_ T) (string, error) { // want BadReturnErrorAt2:"badFunc"
+	return "", errors.New("error at 2")
+}

--- a/passes/wraperr/wraperr_test.go
+++ b/passes/wraperr/wraperr_test.go
@@ -18,8 +18,8 @@ func Test(t *testing.T) {
 	wraperr.LogLevel = "INFO"
 	wraperr.ReportMode = "BOTH"
 	wraperr.EnableErrGroupAnalyzer = true
-	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,a/a10defer,eg/eg01core,eg/eg02generics,eg/eg03interface"
-	wraperr.IncludePackages = "^(a/a01core|a/a02phi|a/a03interface|a/a04closure|a/a05global|a/a06parameter|a/a07generics|a/a08import/a|a/a08import/includedpkg|a/a09cyclic|a/a10defer|eg/eg01core|eg/eg02generics|eg/eg03interface)$"
+	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,a/a10defer,a/a21returnindex,eg/eg01core,eg/eg02generics,eg/eg03interface"
+	wraperr.IncludePackages = "^(a/a01core|a/a02phi|a/a03interface|a/a04closure|a/a05global|a/a06parameter|a/a07generics|a/a08import/a|a/a08import/includedpkg|a/a09cyclic|a/a10defer|a/a21returnindex|eg/eg01core|eg/eg02generics|eg/eg03interface)$"
 	wraperr.ExcludePackages = "(.+/)?vendor$"
 	analysistest.Run(t, testdata, wraperr.Analyzer, strings.Split(pkgs, ",")...)
 }


### PR DESCRIPTION
Fix Error Position Analysis in Generic Function Calls

When a function (A) calls a generic function (B), wraperr incorrectly uses the caller's
error position to analyze the callee's return values. This leads to incorrect error
handling analysis when the error positions differ between the caller and callee.

Example:
```go
func A() (bool, error) {     // error at index 1
    err := B()               // error at index 0
    if err != nil {
        return false, err
    }
    // ...
}

func B[T any](_ T) error {
    return errors.New("err")
}
```

Before this fix, wraperr would analyze function B assuming the error was at
position 1 (inherited from A), when it's actually at position 0.

The fix ensures wraperr uses the correct return value position from the callee's
signature rather than inheriting it from the caller.