### PR TITLE
feat!: Add file logging support for integration with golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can overwrite via commandline option or golangci setting.
 
 ```shell
 $ go install github.com/cloverrose/rpcguard/cmd/callvalidate@latest
+$ go install github.com/cloverrose/rpcguard/cmd/wraperr@latest
 ```
 
 ### Or Build from source
@@ -45,14 +46,14 @@ When you specify config
 
 ```shell
 go vet -vettool=`which rpc_callvalidate` \
-  -rpc_callvalidate.LogLevel=ERROR \
+  -rpc_callvalidate.log.level=ERROR \
    ./...
 ```
 
 ```shell
 go vet -vettool=`which rpc_wraperr` \
   -rpc_wraperr.IncludePackages="$(go list -m)/.*" \
-  -rpc_wraperr.LogLevel=ERROR \
+  -rpc_wraperr.log.level=ERROR \
   -rpc_wraperr.ReportMode=RETURN \
    ./...
 ```
@@ -66,11 +67,11 @@ Here are reference settings
 `.custom-gcl.yml`
 
 ```yaml
-version: v1.63.4
+version: v1.64.8
 plugins:
   - module: 'github.com/cloverrose/rpcguard'
     import: 'github.com/cloverrose/rpcguard'
-    version: v0.4.0
+    version: v0.6.0
 ```
 
 `.golangci.yml`
@@ -82,12 +83,16 @@ linters-settings:
       type: "module"
       description: check if RPC method uses Validate method properly.
       settings:
-        LogLevel: "ERROR"
+        log:
+          level: "ERROR"
+          file: "./log.txt"
     rpc_wraperr:
       type: "module"
       description:  check if RPC method returns wrapped error.
       settings:
-        LogLevel: "ERROR"
+        log:
+          level: "ERROR"
+          file: "./log.txt"
         ReportMode: "RETURN"
         IncludePackages: "github.com/cloverrose/linterplayground/.*"
 ```

--- a/passes/callvalidate/callvalidate_test.go
+++ b/passes/callvalidate/callvalidate_test.go
@@ -15,7 +15,7 @@ func Test(t *testing.T) {
 	t.Parallel()
 	testdata := analysistest.TestData()
 	testdata = testutil.WithModules(t, testdata, nil)
-	callvalidate.LogLevel = "INFO"
+	callvalidate.LogConfig.Level = "INFO"
 	callvalidate.ValidateMethods = "github.com/bufbuild/protovalidate-go:Validate,a:customValidate"
 	pkgs := "a"
 	analysistest.Run(t, testdata, callvalidate.Analyzer, strings.Split(pkgs, ",")...)

--- a/passes/callvalidate/config.go
+++ b/passes/callvalidate/config.go
@@ -5,11 +5,15 @@ import (
 	"strings"
 
 	"github.com/cloverrose/rpcguard/pkg/filter"
+	"github.com/cloverrose/rpcguard/pkg/logger"
 )
 
-// LogLevel is configuration of logging level.
-// Available options are DEBUG, INFO, WARN, ERROR
-var LogLevel = "INFO"
+// log related configuration.
+var LogConfig = logger.Config{
+	Level:  "INFO",
+	File:   "",
+	Format: "json",
+}
 
 // ExcludeFiles is configuration which files should be excluded.
 // This is useful to exclude test file, generated files.

--- a/passes/callvalidate/golangci_plugin.go
+++ b/passes/callvalidate/golangci_plugin.go
@@ -3,6 +3,8 @@ package callvalidate
 import (
 	"github.com/golangci/plugin-module-register/register"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/cloverrose/rpcguard/pkg/logger"
 )
 
 func RegisterPlugin() {
@@ -20,7 +22,7 @@ func newPlugin(conf any) (register.LinterPlugin, error) {
 }
 
 type settings struct {
-	LogLevel        string
+	Log             logger.Config
 	ExcludeFiles    string
 	ValidateMethods string
 }
@@ -30,8 +32,14 @@ type plugin struct {
 }
 
 func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
-	if p.settings.LogLevel != "" {
-		LogLevel = p.settings.LogLevel
+	if p.settings.Log.Level != "" {
+		LogConfig.Level = p.settings.Log.Level
+	}
+	if p.settings.Log.File != "" {
+		LogConfig.File = p.settings.Log.File
+	}
+	if p.settings.Log.Format != "" {
+		LogConfig.Format = p.settings.Log.Format
 	}
 	if p.settings.ExcludeFiles != "" {
 		ExcludeFiles = p.settings.ExcludeFiles

--- a/passes/wraperr/config.go
+++ b/passes/wraperr/config.go
@@ -2,11 +2,15 @@ package wraperr
 
 import (
 	"github.com/cloverrose/rpcguard/pkg/filter"
+	"github.com/cloverrose/rpcguard/pkg/logger"
 )
 
-// LogLevel is configuration of logging level.
-// Available options are DEBUG, INFO, WARN, ERROR
-var LogLevel = "INFO"
+// log related configuration.
+var LogConfig = logger.Config{
+	Level:  "INFO",
+	File:   "",
+	Format: "json",
+}
 
 const (
 	reportModeReturn   = "RETURN"

--- a/passes/wraperr/golangci_plugin.go
+++ b/passes/wraperr/golangci_plugin.go
@@ -3,6 +3,8 @@ package wraperr
 import (
 	"github.com/golangci/plugin-module-register/register"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/cloverrose/rpcguard/pkg/logger"
 )
 
 func RegisterPlugin() {
@@ -20,7 +22,7 @@ func newPlugin(conf any) (register.LinterPlugin, error) {
 }
 
 type settings struct {
-	LogLevel               string
+	Log                    logger.Config
 	ReportMode             string
 	IncludePackages        string
 	ExcludePackages        string
@@ -33,8 +35,14 @@ type plugin struct {
 }
 
 func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
-	if p.settings.LogLevel != "" {
-		LogLevel = p.settings.LogLevel
+	if p.settings.Log.Level != "" {
+		LogConfig.Level = p.settings.Log.Level
+	}
+	if p.settings.Log.File != "" {
+		LogConfig.File = p.settings.Log.File
+	}
+	if p.settings.Log.Format != "" {
+		LogConfig.Format = p.settings.Log.Format
 	}
 	if p.settings.ReportMode != "" {
 		ReportMode = p.settings.ReportMode

--- a/passes/wraperr/wraperr_test.go
+++ b/passes/wraperr/wraperr_test.go
@@ -15,7 +15,7 @@ func Test(t *testing.T) {
 	t.Parallel()
 	testdata := analysistest.TestData()
 	testdata = testutil.WithModules(t, testdata, nil)
-	wraperr.LogLevel = "INFO"
+	wraperr.LogConfig.Level = "INFO"
 	wraperr.ReportMode = "BOTH"
 	wraperr.EnableErrGroupAnalyzer = true
 	pkgs := "a/a01core,a/a02phi,a/a03interface,a/a04closure,a/a05global,a/a06parameter,a/a07generics,a/a08import/a,a/a08import/includedpkg,a/a09cyclic,a/a10defer,a/a21returnindex,eg/eg01core,eg/eg02generics,eg/eg03interface"


### PR DESCRIPTION
When rpcguard is used as a golangci-lint plugin, stdout is captured by the parent process, making console logs inaccessible. This update implements file-based logging to ensure visibility of diagnostic information in such environments.

**BREAKING CHANGE**: The previous `LogLevel` configuration has been restructured and moved under the `log.level` namespace to accommodate the expanded logging functionality.